### PR TITLE
room front/ jacoco / sonarqube

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,9 @@ plugins {
 	id 'org.springframework.boot' version '3.1.0'
 	id 'io.spring.dependency-management' version '1.1.0'
 	id 'jacoco'
+
+//	id "org.sonarqube" version "4.2.1.3168"
+
 }
 
 group = 'com.example'
@@ -70,7 +73,7 @@ jacoco {
 jacocoTestReport {
 	reports {
 		html.enabled true
-		xml.enabled false
+		xml.enabled true
 		csv.enabled false
 	}
 	finalizedBy 'jacocoTestCoverageVerification'
@@ -85,7 +88,7 @@ jacocoTestCoverageVerification {
 			limit {
 				counter = "LINE"
 				value = 'COVEREDRATIO'
-				minimum = 0.60
+//				minimum = 0.60
 			}
 			excludes = [
 			        "**.standard.util.*",
@@ -101,3 +104,21 @@ jacocoTestCoverageVerification {
 
 	}
 }
+
+//sonarqube {
+//	properties {
+//
+//		property "sonar.projectKey" ,"mnm"
+//		property "sonar.projectName",'mnm'
+//		property "sonar.host.url", "http://localhost:9000"
+//		property "sonar.token","sqp_04241f5a03aa0b2dbf612ac7a8273c06aeaa061f"
+//		property "sonar.language", "java"
+//		property "sonar.sourceEncoding", "UTF-8"
+//		property "sonar.sources", "src/main/java"
+//		property "sonar.tests", "src/test/java"
+//		property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/test/jacocoTestReport.xml" // jacoco xml 파일 위치
+//		property "sonar.java.binaries", "${buildDir}/classes"
+//		property "sonar.test.inclusions", "**/*Test.java"
+//		property "sonar.exclusions", "**/util/**, **/support/**, **/dto/**" // 제외할 클래스들
+//	}
+//}

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.0'
 	id 'io.spring.dependency-management' version '1.1.0'
+	id 'jacoco'
 }
 
 group = 'com.example'
@@ -59,4 +60,44 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy 'jacocoTestReport'
+}
+
+jacoco {
+	toolVersion = "0.8.7"
+}
+
+jacocoTestReport {
+	reports {
+		html.enabled true
+		xml.enabled false
+		csv.enabled false
+	}
+	finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			enabled = true // 활성화
+			element = 'CLASS' // 클래스 단위로 커버리지 체크
+
+			limit {
+				counter = "LINE"
+				value = 'COVEREDRATIO'
+				minimum = 0.60
+			}
+			excludes = [
+			        "**.standard.util.*",
+					"**.MnM.base.*",
+					"**.main.generated.*",
+					"**.entity.*",
+					"**.dto.*",
+					"**.event.*",
+					"**.repository.*",
+					"**.controller.LikeablePersonController.LikeForm"
+			]
+		}
+
+	}
 }

--- a/src/main/java/com/example/MnM/MnMApplication.java
+++ b/src/main/java/com/example/MnM/MnMApplication.java
@@ -2,7 +2,15 @@ package com.example.MnM;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
+@EnableJpaAuditing
+@EnableCaching
+@EnableScheduling
 @SpringBootApplication
 public class MnMApplication {
 

--- a/src/main/java/com/example/MnM/base/config/WebSocketConfig.java
+++ b/src/main/java/com/example/MnM/base/config/WebSocketConfig.java
@@ -14,7 +14,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/sub");
+        registry.enableSimpleBroker("/sub","/single");
         registry.setApplicationDestinationPrefixes("/pub");
     }
 

--- a/src/main/java/com/example/MnM/boundedContext/chat/controller/MessageController.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/controller/MessageController.java
@@ -16,8 +16,15 @@ public class MessageController {
 
     @MessageMapping("/chat/{roomId}")
     @SendTo("/sub/chat/{roomId}")
-    public ChatMessageDto sendMessage(@DestinationVariable String roomId, ChatMessageDto messageDto) {
+    public ChatMessageDto sendManyToMany(@DestinationVariable String roomId, ChatMessageDto messageDto) {
+        chatService.saveChat(roomId, messageDto);
+        return messageDto;
+    }
 
+    @MessageMapping("/chatOne/{roomId}")
+    @SendTo("/single/chat/{roomId}")
+    public ChatMessageDto sendOneToOne(@DestinationVariable String roomId, ChatMessageDto messageDto) {
+        chatService.saveChat(roomId, messageDto);
         return messageDto;
     }
 }

--- a/src/main/java/com/example/MnM/boundedContext/chat/controller/RoomController.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/controller/RoomController.java
@@ -22,7 +22,7 @@ public class RoomController {
     private final Rq rq;
 
     @GetMapping("/rooms")
-    public String first(Model model) {
+    public String roomList(Model model) {
         List<ChatRoom> rooms = roomService.findAll();
         model.addAttribute("rooms",rooms);
 
@@ -34,7 +34,7 @@ public class RoomController {
 //        Long roomId = roomService.createRoom(rq.getMember().getUsername());
         Long roomId = roomService.createRoom();
         model.addAttribute("roomId",roomId);
-        return "redirect:/chat/rooms";
+        return rq.redirectWithMsg("/chat/rooms","채팅 방이 생성되었습니다.");
     }
 
     @GetMapping("/room/{roomId}")

--- a/src/main/java/com/example/MnM/boundedContext/chat/event/ChatEventListener.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/event/ChatEventListener.java
@@ -1,7 +1,6 @@
 package com.example.MnM.boundedContext.chat.event;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
@@ -9,12 +8,12 @@ import org.springframework.web.socket.messaging.SessionConnectedEvent;
 
 
 @RequiredArgsConstructor
-//@Component
+@Component
 public class ChatEventListener {
 
     private final SimpMessagingTemplate messagingTemplate;
 
-    @EventListener
+//    @EventListener
     public void handleWebSocketConnectListener(SessionConnectedEvent event) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
         String username = accessor.getUser().getName();

--- a/src/main/java/com/example/MnM/boundedContext/chat/repository/RoomRepository.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/repository/RoomRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoomRepository extends JpaRepository<ChatRoom, Long> {
 
+    void deleteByUniqueId(String roomId);
 }

--- a/src/main/java/com/example/MnM/boundedContext/chat/service/ChatSchedulerService.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/service/ChatSchedulerService.java
@@ -1,0 +1,23 @@
+package com.example.MnM.boundedContext.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ChatSchedulerService {
+
+    private final RedisTemplate<String,Object> redisTemplate;
+
+    @Async
+    @Scheduled(cron = "0 0 * * * *")
+    public void persistsChat() {
+    }
+
+}

--- a/src/main/java/com/example/MnM/boundedContext/chat/service/ChatService.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/service/ChatService.java
@@ -4,8 +4,10 @@ import com.example.MnM.boundedContext.chat.dto.ChatMessageDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class ChatService {
 

--- a/src/main/java/com/example/MnM/boundedContext/chat/service/RoomService.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/service/RoomService.java
@@ -5,15 +5,17 @@ import com.example.MnM.boundedContext.chat.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class RoomService {
 
-    private final RedisTemplate<String,Object> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
     private final RoomRepository roomRepository;
 
 
@@ -21,7 +23,7 @@ public class RoomService {
         return roomRepository.findAll();
     }
 
-    public Long createRoom( ) {
+    public Long createRoom() {
         String roomSecretId = UUID.randomUUID().toString();
 
         ChatRoom room = roomRepository.save(ChatRoom.builder()
@@ -30,8 +32,16 @@ public class RoomService {
                 .name(roomSecretId)
                 .build());
 
-        return room.getId();
+        Long roomId = room.getId();
+        redisTemplate.opsForList().rightPush("rooms", roomId);
 
+        return roomId;
+
+    }
+
+    public void deleteRoom(String roomId) {
+        roomRepository.deleteByUniqueId(roomId);
+        redisTemplate.opsForList().remove("rooms",1,roomId);
     }
 
     public ChatRoom findById(Long id) {

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    generate-ddl: true
+
+  data:
+    redis:
+      database: 1
+
+
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
     redis:
       host: 127.0.0.1
       port: 6379
-
+      database: 0
 
 
 decorator:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,10 +13,10 @@ spring:
       ddl-auto: create
     properties:
       hibernate:
-
         show_sql: false
         format_sql: false
         use_sql_comments: false
+        default_batch_fetch_size: 200
 
   data:
     redis:

--- a/src/main/resources/static/css/room.css
+++ b/src/main/resources/static/css/room.css
@@ -1,0 +1,20 @@
+.scrollbar-w-2::-webkit-scrollbar {
+    width: 0.25rem;
+    height: 0.25rem;
+}
+
+.scrollbar-track-blue-lighter::-webkit-scrollbar-track {
+    --bg-opacity: 1;
+    background-color: #f7fafc;
+    background-color: rgba(247, 250, 252, var(--bg-opacity));
+}
+
+.scrollbar-thumb-blue::-webkit-scrollbar-thumb {
+    --bg-opacity: 1;
+    background-color: #edf2f7;
+    background-color: rgba(237, 242, 247, var(--bg-opacity));
+}
+
+.scrollbar-thumb-rounded::-webkit-scrollbar-thumb {
+    border-radius: 0.25rem;
+}

--- a/src/main/resources/static/js/room.js
+++ b/src/main/resources/static/js/room.js
@@ -30,7 +30,7 @@ stompClient.connect({}, function(frame) {
     });
 
     window.addEventListener("beforeunload", function(event) {
-        stompClient.disconnect();
+        // stompClient.disconnect();
     });
 });
 
@@ -85,3 +85,38 @@ function showMessageOutput(messageData) {
     // 스크롤을 최신 메시지 위치로 이동합니다.
     messages.scrollTop = messages.scrollHeight;
 }
+
+document.addEventListener("DOMContentLoaded", function() {
+    // 모달 토글 버튼을 모두 선택합니다.
+    const toggleButtons = document.querySelectorAll('[data-modal-toggle]');
+
+    toggleButtons.forEach(function(button) {
+        button.addEventListener('click', function() {
+            // data-modal-toggle 속성에서 대상 모달의 id를 가져옵니다.
+            const targetModalId = button.getAttribute('data-modal-toggle');
+            const targetModal = document.getElementById(targetModalId);
+
+            // 현재 모달의 표시 상태를 확인하고 토글합니다.
+            if (targetModal.classList.contains('hidden')) {
+                targetModal.classList.remove('hidden');
+            } else {
+                targetModal.classList.add('hidden');
+            }
+        });
+    });
+
+    const closeButton = document.querySelector('#closeButton');
+    const enterButton = document.querySelector('#enterButton');
+    const exitButton = document.querySelector('#exitButton');
+
+    closeButton.addEventListener('click', () => {
+        window.location.href = 'http://localhost:8080/chat/rooms';
+    });
+    exitButton.addEventListener('click', (navigateAway => {
+        window.location.href = 'http://localhost:8080/chat/rooms';
+    }));
+    enterButton.addEventListener('click', () => {
+        const modal = document.querySelector('#exit');
+        modal.classList.add('hidden');
+    });
+});

--- a/src/main/resources/static/js/room.js
+++ b/src/main/resources/static/js/room.js
@@ -1,0 +1,87 @@
+const el = document.getElementById('messages')
+el.scrollTop = el.scrollHeight
+
+const socket = new SockJS('http://localhost:8080/chat/connect');
+const stompClient = Stomp.over(socket);
+
+
+// DOM Element
+const messages = document.getElementById('messages');
+const messageInput = document.getElementById('messageInput');
+const sendButton = document.getElementById('sendButton');
+
+stompClient.connect({}, function(frame) {
+    // 구독 설정
+    stompClient.subscribe('/sub/chat/' + roomId, function(messageOutput) {
+        showMessageOutput(JSON.parse(messageOutput.body));
+    });
+
+    // Send 버튼 이벤트
+    sendButton.addEventListener('click', function() {
+        sendMessage(messageInput.value);
+        messageInput.value = '';
+    });
+
+    messageInput.addEventListener('keydown', function(event) {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            sendButton.click();
+        }
+    });
+
+    window.addEventListener("beforeunload", function(event) {
+        stompClient.disconnect();
+    });
+});
+
+function sendMessage(message) {
+    stompClient.send("/pub/chat/" + roomId, {},
+        JSON.stringify({
+            'roomId': roomId,
+            'message': message,
+            'sender': username
+        }));
+}
+
+function showMessageOutput(messageData) {
+    // 메시지를 담을 chat-message div를 생성합니다.
+    const messageElement = document.createElement('div');
+    messageElement.classList.add('chat-message');
+
+    // 메시지의 상세 내용을 담을 div를 생성합니다.
+    const detailsElement = document.createElement('div');
+    const spanElement = document.createElement('span');
+    const textElement = document.createElement('div');
+    textElement.classList.add('flex', 'flex-col', 'space-y-2', 'text-xs', 'max-w-xs', 'mx-2', 'items-start');
+    spanElement.classList.add('px-4', 'py-2', 'rounded-lg', 'inline-block');
+    console.log(messageData.message);
+    spanElement.textContent = messageData.message;
+    // <div className="w-6 h-6 rounded-full order-2">hello</div>
+    const senderElement = document.createElement('div');
+    senderElement.textContent = messageData.sender;
+    senderElement.classList.add('w-6', 'h-6', 'rounded-full');
+
+    if (messageData.sender === username) {
+        detailsElement.classList.add('flex', 'items-end', 'justify-end');
+        textElement.classList.add('order-1', 'items-end');
+        spanElement.classList.add('rounded-br-none', 'bg-blue-600', 'text-white');
+        senderElement.classList.add('order-2');
+    } else {
+        detailsElement.classList.add('flex', 'items-end');
+        textElement.classList.add('order-2', 'items-start');
+        spanElement.classList.add('rounded-bl-none', 'bg-gray-300', 'text-gray-600');
+        senderElement.classList.add('order-1');
+    }
+
+    // 생성된 모든 요소를 조립합니다.
+    textElement.appendChild(spanElement);
+    detailsElement.appendChild(textElement);
+    detailsElement.appendChild(senderElement);
+    messageElement.appendChild(detailsElement);
+
+    // 완성된 메시지를 메시지 목록에 추가합니다.
+    messages.appendChild(messageElement);
+
+    // 스크롤을 최신 메시지 위치로 이동합니다.
+    messages.scrollTop = messages.scrollHeight;
+}

--- a/src/main/resources/templates/chat/room.html
+++ b/src/main/resources/templates/chat/room.html
@@ -1,55 +1,56 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html lang="ko" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout.html}">
 <head>
   <title>Chat Room</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.1.4/sockjs.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+  <link rel="stylesheet" href="/css/room.css">
 </head>
 <main layout:fragment="content" class="flex-col flex items-center justify-center">
-  <div id="messages"></div>
-  <input type="text" id="messageInput">
-  <button id="sendButton">Send</button>
+  <div class="flex-1 p:2 sm:p-6 max-w-2xl mx-auto w-full  justify-between flex flex-col h-screen">
+    <div class="flex sm:items-center justify-between py-3 border-b-2 border-gray-200">
+      <div class="relative flex items-center space-x-4">
+      </div>
+    </div>
+    <div id="messages" class="flex flex-col space-y-4 p-3 overflow-y-auto scrollbar-thumb-blue scrollbar-thumb-rounded scrollbar-track-blue-lighter scrollbar-w-2 scrolling-touch">
+      <div class="chat-message">
+        <div class="flex items-end">
+          <div class="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
+            <div><span class="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-300 text-gray-600">Thanks for your message David. I thought I'm alone with this issue. Please, ? the issue to support it :)</span></div>
+          </div>
+          <div class="w-6 h-6 rounded-full order-1">you</div>
+        </div>
+      </div>
+      <div class="chat-message">
+        <div class="flex items-end justify-end">
+          <div class="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
+            <div><span class="px-4 py-2 rounded-lg inline-block rounded-br-none bg-blue-600 text-white ">yes, I have a mac. I never had issues with root permission as well, but this helped me to solve the problem</span></div>
+          </div>
+          <div class="w-6 h-6 rounded-full order-2">hello</div>
+        </div>
+      </div>
+    </div>
+    <div class="border-t-2 border-gray-200 px-4 pt-4 mb-2 sm:mb-0">
+      <div class="relative flex">
+        <input id="messageInput" type="text" placeholder="Write your message!" class="w-full focus:outline-none focus:placeholder-gray-400 text-gray-600 placeholder-gray-600 pl-6 bg-gray-200 rounded-md py-3">
+        <div class="absolute right-0 items-center inset-y-0 hidden sm:flex">
+          <button id="sendButton" type="button" class="inline-flex items-center justify-center rounded-lg px-4 py-3 transition duration-500 ease-in-out text-white bg-blue-500 hover:bg-blue-400 focus:outline-none">
+            <span class="font-bold">Send</span>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-6 w-6 ml-2 transform rotate-90">
+              <path d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112 0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z"></path>
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <script th:inline="javascript">
-    const socket = new SockJS('http://localhost:8080/chat/connect');
-    const stompClient = Stomp.over(socket);
-
+    const username = "hello";
     const roomId = /*[[${room.id}]]*/ null;  // 채팅방 id는 여기에 할당하십시오.
+    </script>
+  <script th:src="@{/js/room.js}"></script>
 
-
-    // DOM Element
-    const messages = document.getElementById('messages');
-    const messageInput = document.getElementById('messageInput');
-    const sendButton = document.getElementById('sendButton');
-
-    stompClient.connect({}, function(frame) {
-      // 구독 설정
-      stompClient.subscribe('/sub/chat/' + roomId, function(messageOutput) {
-        showMessageOutput(JSON.parse(messageOutput.body).message);
-      });
-
-      // Send 버튼 이벤트
-      sendButton.addEventListener('click', function() {
-        sendMessage(messageInput.value);
-        messageInput.value = '';
-      });
-
-      window.addEventListener("beforeunload", function(event) {
-        stompClient.disconnect();
-      });
-    });
-
-    function sendMessage(message) {
-      stompClient.send("/pub/chat/" + roomId, {}, JSON.stringify({ 'roomId': roomId, 'message': message, 'sender': 'username' }));
-    }
-
-    function showMessageOutput(messageOutput) {
-      const response = document.createElement('p');
-      response.style.wordWrap = 'break-word';
-      response.appendChild(document.createTextNode(messageOutput));
-      messages.appendChild(response);
-      console.log("메시지 옴")
-    }
-  </script>
 </main>
 </html>

--- a/src/main/resources/templates/chat/room.html
+++ b/src/main/resources/templates/chat/room.html
@@ -43,8 +43,45 @@
           </button>
         </div>
       </div>
+      <button data-modal-target="exit" data-modal-toggle="exit" class="w-full btn btn-primary my-6 btn-outline " type="button">
+        <i class="fa-solid fa-door-open mx-2"></i>나가기
+      </button>
+      <!-- Main modal -->
+      <div id="exit" tabindex="-1" aria-hidden="true" class="fixed top-0 left-0 right-0 z-50 hidden w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full flex items-center justify-center">
+        <div class="relative w-full max-w-2xl max-h-full">
+          <!-- Modal content -->
+          <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
+            <!-- Modal header -->
+            <div class="flex items-start justify-between p-4 border-b rounded-t dark:border-gray-600">
+              <h3 class="text-xl font-semibold text-gray-900 dark:text-white">
+                대화방
+              </h3>
+              <button id="closeButton" type="button" class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white" data-modal-hide="defaultModal">
+                <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
+                <span class="sr-only">닫기</span>
+              </button>
+            </div>
+            <!-- Modal body -->
+            <div class="p-6 space-y-6">
+              <p class="text-base text-2xl leading-relaxed text-gray-500 dark:text-gray-400">
+                정말 나가시겠습니까?
+              </p>
+
+            </div>
+            <!-- Modal footer -->
+            <div class="flex justify-evenly items-center p-6 space-x-2 border-t border-gray-200 rounded-b dark:border-gray-600">
+              <button id="enterButton" data-modal-hide="defaultModal" type="button" class="text-2xl bg-gray-300 hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-lg border border-gray-200 text-sm font-medium px-5 py-2.5 hover:text-gray-900 focus:z-10 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-500 dark:hover:text-white dark:hover:bg-gray-600 dark:focus:ring-gray-600">입장하기</button>
+              <button id="exitButton" data-modal-hide="defaultModal" type="button" class="text-2xl bg-blue-300 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">나가기</button>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
+
+
   </div>
+
+
 
   <script th:inline="javascript">
     const username = "hello";

--- a/src/test/java/com/example/MnM/MnMApplicationTests.java
+++ b/src/test/java/com/example/MnM/MnMApplicationTests.java
@@ -2,7 +2,9 @@ package com.example.MnM;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class MnMApplicationTests {
 

--- a/src/test/java/com/example/MnM/boundedContext/chat/controller/RoomControllerTest.java
+++ b/src/test/java/com/example/MnM/boundedContext/chat/controller/RoomControllerTest.java
@@ -1,0 +1,79 @@
+package com.example.MnM.boundedContext.chat.controller;
+
+import com.example.MnM.boundedContext.chat.entity.ChatRoom;
+import com.example.MnM.boundedContext.chat.repository.RoomRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@SpringBootTest
+class RoomControllerTest {
+
+    @Autowired
+    RoomRepository roomRepository;
+
+    @Autowired
+    RoomController roomController;
+
+    @Autowired
+    MockMvc mvc;
+
+    @DisplayName("채팅 방 목록")
+    @Test
+    void rooms() throws Exception {
+        mvc.perform(get("/chat/rooms"))
+                .andExpect(handler().handlerType(RoomController.class))
+                .andExpect(handler().methodName("roomList"))
+                .andExpect(view().name("chat/rooms"))
+                .andExpect(status().isOk());
+    }
+
+
+    @DisplayName("채팅 방 생성")
+    @Test
+    void createRoom() throws Exception {
+        mvc.perform(post("/chat/create/room")
+                        .with(csrf()))
+                .andExpect(handler().handlerType(RoomController.class))
+                .andExpect(handler().methodName("createRoom"))
+                .andExpect(redirectedUrlPattern("/chat/rooms**"));
+
+        List<ChatRoom> rooms = roomRepository.findAll();
+        assertThat(rooms).hasSize(1);
+    }
+
+    @DisplayName("채팅 방 입장")
+    @Test
+    void enterRoom() throws Exception {
+
+        ChatRoom room = ChatRoom.builder().build();
+        roomRepository.save(room);
+
+        mvc.perform(get("/chat/room/%s".formatted(room.getId())))
+                .andExpect(handler().handlerType(RoomController.class))
+                .andExpect(handler().methodName("entranceRoom"))
+                .andExpect(model().attributeExists("room"))
+                .andExpect(view().name("chat/room"))
+                .andExpect(status().is2xxSuccessful());
+
+    }
+
+
+
+}

--- a/src/test/java/com/example/MnM/boundedContext/chat/controller/RoomControllerTest.java
+++ b/src/test/java/com/example/MnM/boundedContext/chat/controller/RoomControllerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,8 +36,9 @@ class RoomControllerTest {
     MockMvc mvc;
 
     @DisplayName("채팅 방 목록")
+    @WithUserDetails("user1")
     @Test
-    void rooms() throws Exception {
+    void showRoomList() throws Exception {
         mvc.perform(get("/chat/rooms"))
                 .andExpect(handler().handlerType(RoomController.class))
                 .andExpect(handler().methodName("roomList"))
@@ -46,6 +48,7 @@ class RoomControllerTest {
 
 
     @DisplayName("채팅 방 생성")
+    @WithUserDetails("user1")
     @Test
     void createRoom() throws Exception {
         mvc.perform(post("/chat/create/room")
@@ -59,6 +62,7 @@ class RoomControllerTest {
     }
 
     @DisplayName("채팅 방 입장")
+    @WithUserDetails("user1")
     @Test
     void enterRoom() throws Exception {
 
@@ -71,7 +75,6 @@ class RoomControllerTest {
                 .andExpect(model().attributeExists("room"))
                 .andExpect(view().name("chat/room"))
                 .andExpect(status().is2xxSuccessful());
-
     }
 
 


### PR DESCRIPTION
## PR 생성이유
---
#### room html을 tailwind를 이용하여 꾸몄습니다.
#### jacoco를 도입하였습니다.

## 주요 변화사항
---
####  1. room html을 대폭 변경 -> 시큐리티 적용 안된 상태입니다.
#### 2.  message 1:1 n:m 분리
#### 3. Scheduler 도입 -> 아직 기능 구현 X
#### 4. redis database 분리
#### 5. jacoco 도입 -> 빌드할 경우 실패할 확률이 높습니다.(단순 테스트는 가능)
#### 6. jacoco -> sonarqube 연동(주석 처리했습니다. 나중에 사용가능하면 그 때 사용하겠습니다.)
#### 7. test yml 추가 -> h2사용

## 이 부분을 중점으로 봐주세요
---
#### 1. stomp를 이용한 채팅 방 기능 중 더 구현할 것은 없는지 봐주시면 좋을 것 같습니다.
#### 2. 보안의 경우 어떻게 구현하면 좋을지 봐주시면 좋을 것 같습니다. (1:1채팅인데 다른 사람이 접근하는 경우)
#### 3. front의 경우 더 구현하거나 고칠점은 없는지 봐주시면 감사합니다.
#### 4. chatLog의 경우 저장을 어떤 방식으로 할지 봐주시면 감사합니다.

close #13 