### PR TITLE
마이페이지, data.sql, soft delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 src/main/generated
 src/main/resources/application-secret.yml
+src/main/resources/data.sql

--- a/src/main/java/com/example/MnM/base/initData/NotProd.java
+++ b/src/main/java/com/example/MnM/base/initData/NotProd.java
@@ -24,14 +24,14 @@ public class NotProd {
 
                 Member member1 = memberService.join(new MemberDto(
                         "user1", "1234", "user1@email.com", "홍길동", "홍길동", 170, 20, "서울", "남자", "ENFP",
-                        "운동", "안녕하세요", ""
+                        "운동", "안녕하세요", "", Boolean.FALSE
                 )).getData();
 
 
                 Member member2 = memberService.join(new MemberDto(
                         "user3", "1234", "user2@email.com", "임꺽정", "임꺽정", 170, 20, "서울", "남자", "ENFP",
 
-                        "운동", "안녕하세요", ""
+                        "운동", "안녕하세요", "", Boolean.FALSE
                 )).getData();
 
                 //임의로 회원 생성

--- a/src/main/java/com/example/MnM/base/initData/NotProd.java
+++ b/src/main/java/com/example/MnM/base/initData/NotProd.java
@@ -22,7 +22,7 @@ public class NotProd {
             @Transactional
             public void run(String... args) throws Exception {
 
-                Member member1 = memberService.join(new MemberDto(
+                /*Member member1 = memberService.join(new MemberDto(
                         "user1", "1234", "user1@email.com", "홍길동", "홍길동", 170, 20, "서울", "남자", "ENFP",
                         "운동", "안녕하세요", "", Boolean.FALSE
                 )).getData();
@@ -32,9 +32,7 @@ public class NotProd {
                         "user3", "1234", "user2@email.com", "임꺽정", "임꺽정", 170, 20, "서울", "남자", "ENFP",
 
                         "운동", "안녕하세요", "", Boolean.FALSE
-                )).getData();
-
-                //임의로 회원 생성
+                )).getData();*/
             }
         };
     }

--- a/src/main/java/com/example/MnM/base/initData/NotProd.java
+++ b/src/main/java/com/example/MnM/base/initData/NotProd.java
@@ -22,17 +22,6 @@ public class NotProd {
             @Transactional
             public void run(String... args) throws Exception {
 
-                /*Member member1 = memberService.join(new MemberDto(
-                        "user1", "1234", "user1@email.com", "홍길동", "홍길동", 170, 20, "서울", "남자", "ENFP",
-                        "운동", "안녕하세요", "", Boolean.FALSE
-                )).getData();
-
-
-                Member member2 = memberService.join(new MemberDto(
-                        "user3", "1234", "user2@email.com", "임꺽정", "임꺽정", 170, 20, "서울", "남자", "ENFP",
-
-                        "운동", "안녕하세요", "", Boolean.FALSE
-                )).getData();*/
             }
         };
     }

--- a/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.Positive;
 import lombok.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,6 +51,12 @@ public class MemberController {
             return rq.redirectWithMsg("/member/join", joinRs);
         }
         return rq.redirectWithMsg("/member/login", joinRs);
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/me")
+    public String showMe(Model model) {
+        return "member/me";
     }
 
 

--- a/src/main/java/com/example/MnM/boundedContext/member/dto/MemberDto.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/dto/MemberDto.java
@@ -10,33 +10,36 @@ import lombok.*;
 @Getter
 @ToString
 @Setter
+@RequiredArgsConstructor
 public class MemberDto {
 
-    @NotEmpty
+    @NotBlank
     private String userId; //id
-    @NotEmpty
+    @NotBlank
     private String password;
-    @NotEmpty
+    @NotBlank
     private String email;
-    @NotEmpty
+    @NotBlank
     private String username; //이름
-    @NotEmpty
+    @NotBlank
     private String nickname; //닉네임
     @Positive
     private Integer height; //키
     @Positive
     private Integer age; //나이;
-    @NotEmpty
+    @NotBlank
     private String locate; //지역
-    @NotEmpty
+    @NotBlank
     private String gender; //성별
-    @NotEmpty
+    @NotBlank
     private String mbti; //mbti
-    @NotEmpty
+    @NotBlank
     private String hobby; //취미
-    @NotEmpty
+    @NotBlank
     private String introduce; //자기소개
 
     private String profileImage;
+
+    private boolean deleted;
 
 }

--- a/src/main/java/com/example/MnM/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/entity/Member.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
+import org.hibernate.annotations.SQLDelete;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
@@ -23,6 +24,7 @@ import java.util.List;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@SQLDelete(sql = "UPDATE member SET deleted = true WHERE id = ?")
 public class Member extends BaseEntity {
     private String userId; //id
     private String password; //pw
@@ -42,6 +44,15 @@ public class Member extends BaseEntity {
     private String hobby; //취미
     private String profileImage; //프로필사진, 임시로 만듬
     private String introduce; //자기소개
+
+    private boolean deleted = Boolean.FALSE; //soft delete
+
+    public Member(String userId, String username, String password) {
+        this.userId = userId;
+        this.username = username;
+        this.password =password;
+    }
+
 
 
     public List<? extends GrantedAuthority> getGrantedAuthorities() {

--- a/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
@@ -74,4 +74,12 @@ public class MemberService {
     public Optional<Member> findByUserName(String username) {
         return memberRepository.findByUsername(username);
     }
+
+    public Member saveMember(Member member){
+        return memberRepository.save(member);
+    }
+
+    public void deleteMember(Member member){
+        memberRepository.delete(member);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,14 +17,17 @@ spring:
         format_sql: false
         use_sql_comments: false
         default_batch_fetch_size: 200
+    defer-datasource-initialization: true
+
 
   data:
     redis:
       host: 127.0.0.1
       port: 6379
       database: 0
-
-
+  sql:
+    init:
+      mode: always
 decorator:
   datasource:
     p6spy:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,2 @@
+INSERT INTO member (age,create_date,deleted,email,gender,height,hobby,introduce,locate,mbti,modify_date,nickname,password,profile_image,provider_type,user_id,username)
+VALUES (20,'2023-06-24T01:15:54',false,'user2@email.com','남자',170,'운동','안녕하세요','서울','ENFP','2023-06-24T01:15:54','임꺽정','{bcrypt}$2a$10$p2RfN34zGPnclC1gYwGGaenHWcQIMQda2fVoa.BcPk2cXseHMbSa2',NULL,NULL,'user3','임꺽정');

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,2 +1,2 @@
 INSERT INTO member (age,create_date,deleted,email,gender,height,hobby,introduce,locate,mbti,modify_date,nickname,password,profile_image,provider_type,user_id,username)
-VALUES (20,'2023-06-24T01:15:54',false,'user2@email.com','남자',170,'운동','안녕하세요','서울','ENFP','2023-06-24T01:15:54','임꺽정','{bcrypt}$2a$10$p2RfN34zGPnclC1gYwGGaenHWcQIMQda2fVoa.BcPk2cXseHMbSa2',NULL,NULL,'user3','임꺽정');
+VALUES (20,'2023-06-24T01:15:54',false,'user2@email.com','남자',170,'운동','안녕하세요','서울','ENFP','2023-06-24T01:15:54','임꺽정','$2a$10$p2RfN34zGPnclC1gYwGGaenHWcQIMQda2fVoa.BcPk2cXseHMbSa2',NULL,NULL,'user3','임꺽정');

--- a/src/main/resources/data.sql.default
+++ b/src/main/resources/data.sql.default
@@ -1,0 +1,1 @@
+INSERT INTO (~,~,~) VALUES (~,~,~);

--- a/src/main/resources/templates/header/header.html
+++ b/src/main/resources/templates/header/header.html
@@ -72,7 +72,7 @@
         <ul tabindex="0" class="mt-3 p-2 shadow menu menu-compact dropdown-content bg-base-100 rounded-box w-52">
 
           <li th:if="${@rq.isLogin()}">
-            <a class="justify-between">
+            <a href="/member/me" class="justify-between">
               마이페이지
               <span class="badge">New</span>
             </a>

--- a/src/main/resources/templates/member/me.html
+++ b/src/main/resources/templates/member/me.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout.html}">
+<head>
+  <meta charset="UTF-8"
+        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <title>myPage</title>
+</head>
+<body layout:fragment="content" class="flex-col flex items-center justify-center">
+<main class="pt-2">
+  <table class="table" style="width: 500px">
+    <tr>
+      <th>이름</th>
+      <td th:text="${@rq.member.getUsername()}" colspan="2"></td>
+    </tr>
+    <tr>
+      <th>아이디</th>
+      <td th:text="${@rq.member.getUserId()}" colspan="2"></td>
+    </tr>
+    <tr>
+      <th>닉네임</th>
+      <td th:text="${@rq.member.getNickname()}" colspan="2"></td>
+    </tr>
+    <tr>
+      <th>이메일</th>
+      <td th:text="${@rq.member.getEmail()}" colspan="2"></td>
+    </tr>
+    <tr>
+      <th>가입일</th>
+      <td th:text="${@rq.member.getCreateDate()}" colspan="2"></td>
+    </tr>
+    <tr>
+      <th>MBTI</th>
+      <td th:text="${@rq.member.getMbti()}" colspan="2"></td>
+    </tr>
+    <tr>
+      <th>취미</th>
+      <td th:text="${@rq.member.getHobby()}" colspan="2"></td>
+    </tr>
+    <tr>
+      <th>나이</th>
+      <td th:text="${@rq.member.getAge()}" colspan="2"></td>
+    </tr>
+    <tr>
+      <th>키</th>
+      <td th:text="${@rq.member.getHeight()}" colspan="2"></td>
+    </tr>
+    <tr>
+      <th>지역</th>
+      <td th:text="${@rq.member.getLocate()}" colspan="2"></td>
+    </tr>
+    <tr>
+      <th>자기소개</th>
+      <td th:text="${@rq.member.getIntroduce()}" colspan="2"></td>
+    </tr>
+
+
+  </table>
+
+</main>
+</body>
+</html>

--- a/src/test/java/com/example/MnM/boundedContext/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/MnM/boundedContext/member/controller/MemberControllerTest.java
@@ -1,0 +1,43 @@
+package com.example.MnM.boundedContext.member.controller;
+
+import com.example.MnM.boundedContext.member.entity.Member;
+import com.example.MnM.boundedContext.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+class MemberControllerTest {
+    @Autowired
+    private MemberService memberService;
+
+
+    @Test
+    @DisplayName("soft delete test")
+    public void softDeleteTest() {
+        Member member = new Member("test001", "홍길동", "1234");//testcase
+
+        memberService.saveMember(member);
+        assertThat(memberService.findByUserId(member.getUserId())).isNotNull();
+        assertThat(member.isDeleted()).isFalse();
+
+        memberService.deleteMember(member);
+
+        Optional<Member> afterDelete = memberService.findByUserId(member.getUserId());
+        assertThat(afterDelete).isNotEmpty();
+        assertThat(afterDelete.get().isDeleted()).isTrue();
+
+    }
+
+}


### PR DESCRIPTION
## PR 생성이유
---
마이페이지 생성

## 주요 변화사항
---
![image](https://github.com/LL-MnM/MnM/assets/106876965/fc4b57fe-16de-4012-8b28-f591dd4fb0f3)

마이페이지를 볼 수 있습니다. 수정, 삭제, 메일인증 기능은 없고 회원의 정보만 보여줍니다.
추후 변경사항이 많을것 같아 일단 구성만 만들었습니다.
src/main/gen이 자꾸 올라가서 수정하는 과정에서 파일을 다시 세팅했습니다 변경된 파일이 많을 수 있습니다.
soft delete 를 적용했습니다,  테스트 케이스도 작성했습니다. 
not prod대신 data.sql을 적용했습니다, git ignore 에 추가했습니다
not prod 회원부분 삭제 했습니다.

## 이 부분을 중점으로 봐주세요
---
변경사항 코드가 많이 잡힐 수 있습니다. 
member쪽과 테스트 케이스, data.sql.dafault 부탁드립니다.
보안적인 부분 부탁드립니다.
테스트 케이스가 아직 부실합니다. 

