### PR TITLE
메인페이지 로고 추가 & 소개 페이지 구현

### DIFF
--- a/src/main/java/com/example/MnM/boundedContext/HomeController.java
+++ b/src/main/java/com/example/MnM/boundedContext/HomeController.java
@@ -9,4 +9,9 @@ public class HomeController {
     public String showMain() {
         return "main";
     }
+
+    @GetMapping("/about")
+    public String showAbout(){
+        return "about";
+    }
 }

--- a/src/main/java/com/example/MnM/boundedContext/mbtiTest/controller/MbtiTestController.java
+++ b/src/main/java/com/example/MnM/boundedContext/mbtiTest/controller/MbtiTestController.java
@@ -1,9 +1,11 @@
 package com.example.MnM.boundedContext.mbtiTest.controller;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
+@PreAuthorize("isAuthenticated()")
 public class MbtiTestController {
 
 	@GetMapping("/mbtiTest")

--- a/src/main/resources/templates/about.html
+++ b/src/main/resources/templates/about.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout.html}">
+<head>
+    <title>About</title>
+</head>
+<body layout:fragment="content" class="flex-col flex items-center justify-center">
+<div class="hero min-h-screen">
+    <div class="hero-content flex-col lg:flex-row">
+        <img src="https://imgur.com/VlgimwR.png" class="max-w-sm rounded-lg shadow-2xl" />
+        <div>
+            <h1 class="text-5xl font-bold">About Us</h1>
+            <p class="py-6">마음의 여유가 사라지고  연애를 안하는 사회분위기 가운데 조금 더 쉽게 나와 성향이 맞는
+                사람을 찾기 쉽도록 젊은 세대들 사이 유행하는 mbti기반 데이트 매칭 사이트를 만들게 되었습니다.<br>
+                MBTI는 사람들의 성격을 파악하는 데 효과적인 도구입니다. <br>
+                이 애플리케이션을 통해 사용자는 자신의 성격 유형을 더 잘 이해하고,
+                이에 따라 성격 유형이 비슷하거나 상호 보완적인 이성을 찾을 수 있습니다.
+                또한 사용자가 자신과 다른 성격 유형을 가진 사람들과의 관계를 이해하고 개선하는 데 도움을 줄 수 있습니다.</p>
+            <a href="/mbtiTest" class="btn btn-primary" role="button">Test Start</a>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/header/header.html
+++ b/src/main/resources/templates/header/header.html
@@ -82,6 +82,7 @@
           <li th:if="${@rq.isLogin()}"><a href="javascript:" onclick="$(this).next().submit();">로그아웃</a>
             <form class="!hidden" hidden th:action="|/member/logout|" method="POST"></form></li>
           <li th:if="${@rq.isLogout()}"><a href="/member/join">회원가입</a></li>
+          <li ><a href="/about">소개</a></li>
         </ul>
       </div>
     </div>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -4,11 +4,12 @@
       layout:decorate="~{layout/layout.html}">
 
 
-<div layout:fragment="content" class="flex-grow flex items-center justify-center">
-  <div class="max-w-2xl w-full px-4">
-    <h1>메인페이지 입니다.</h1>
-    <h1>여기에 콘텐츠가 들어갑니다.</h1>
-  </div>
+<body layout:fragment="content" class="flex-col flex items-center justify-center">
+  <main class="max-w-2xl w-full px-4">
+    <a href="/about">
+      <img class="mx-auto" src="https://imgur.com/VlgimwR.png" alt="이미지" />
+    </a>
+  </main>
 
-</div>
+</body>
 </html>


### PR DESCRIPTION
## PR 생성이유
---
close #37 
메인화면 & 소개화면 구현

## 주요 변화사항
---
- 메인페이지 로고 추가 
- 메인화면의 로고를 클릭하면 소개페이지로 이동
- 소개 페이지 구현
- 소개 페이지에서 test start 클릭하면 mbti 테스트로 이동<br>
![image](https://github.com/LL-MnM/MnM/assets/125804214/26c13631-ee12-4a15-92d7-7a7732147dac)
![image](https://github.com/LL-MnM/MnM/assets/125804214/995e7059-8ef1-4255-a263-b2e1e36c33aa)


## 이 부분을 중점으로 봐주세요
---
프론트 부분은 잘 몰라서 제가 할 수 있는 만큼 했습니다.
