### PR TITLE
방 삭제 로직 구현,  yml 암호화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
 	implementation 'com.google.cloud:google-cloud-language:2.21.0'
 	implementation 'com.google.auth:google-auth-library-oauth2-http:1.18.0'
 
+	//jasypt 암호화
+	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
+
 	// Querydsl 추가
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/src/main/java/com/example/MnM/base/config/JasyptConfig.java
+++ b/src/main/java/com/example/MnM/base/config/JasyptConfig.java
@@ -1,0 +1,34 @@
+package com.example.MnM.base.config;
+
+import com.querydsl.core.annotations.Config;
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@EnableEncryptableProperties
+@Configuration
+public class JasyptConfig {
+
+    @Value("${jasypt.encryptor.password}")
+    private String encryptKey;
+
+    @Bean("jasyptStringEncryptor")
+    public StringEncryptor stringEncryptor() {
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword(encryptKey);
+        config.setAlgorithm("PBEWithMD5AndDES");
+        config.setKeyObtentionIterations("1000");
+        config.setPoolSize("1");
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setIvGeneratorClassName("org.jasypt.iv.NoIvGenerator");
+        config.setStringOutputType("base64");
+        encryptor.setConfig(config);
+        return encryptor;
+    }
+}

--- a/src/main/java/com/example/MnM/base/config/WebSocketConfig.java
+++ b/src/main/java/com/example/MnM/base/config/WebSocketConfig.java
@@ -9,6 +9,7 @@ import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -36,4 +37,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registration.interceptors(customWebsocketInterceptor);
     }
 
+    @Override
+    public void configureWebSocketTransport(WebSocketTransportRegistration registry) {
+        registry.setSendTimeLimit(10 * 1000)
+                .setSendBufferSizeLimit(512 * 1024) // 메시지 송신 버퍼 크기 제한 설정 (바이트 단위)
+                .setMessageSizeLimit(8192);
+    }
 }

--- a/src/main/java/com/example/MnM/base/config/websocket/CustomWebsocketInterceptor.java
+++ b/src/main/java/com/example/MnM/base/config/websocket/CustomWebsocketInterceptor.java
@@ -1,8 +1,7 @@
 package com.example.MnM.base.config.websocket;
 
-import com.example.MnM.base.exception.NotValidRoomException;
-import com.example.MnM.boundedContext.chat.entity.ChatRoom;
-import com.example.MnM.boundedContext.chat.service.RoomService;
+import com.example.MnM.boundedContext.room.entity.RoomStatus;
+import com.example.MnM.boundedContext.room.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -31,18 +30,15 @@ public class CustomWebsocketInterceptor implements ChannelInterceptor {
     }
 
     private void isValid(StompHeaderAccessor headerAccessor) {
+        String roomStatus = headerAccessor.getFirstNativeHeader("roomStatus");
 
-        String username = headerAccessor.getFirstNativeHeader("username");
-        String roomId = headerAccessor.getFirstNativeHeader("roomId");
-
-        ChatRoom chatRoom = roomService.findBySecretId(roomId);
-
-        if (!isRoomOwner(username, chatRoom))
-            throw new NotValidRoomException("권한이 없는 방입니다.");
-
+        if (roomStatus.equals(RoomStatus.SINGLE.name())) {
+            String userId = headerAccessor.getFirstNativeHeader("userId");
+            roomService.checkSingleRoom(userId);
+        } else {
+            String roomId = headerAccessor.getFirstNativeHeader("roomId");
+            roomService.checkGroupRoom(roomId);
+        }
     }
 
-    private boolean isRoomOwner(String username, ChatRoom chatRoom) {
-        return chatRoom.getCreateUser().equals(username);
-    }
 }

--- a/src/main/java/com/example/MnM/base/config/websocket/CustomWebsocketInterceptor.java
+++ b/src/main/java/com/example/MnM/base/config/websocket/CustomWebsocketInterceptor.java
@@ -32,7 +32,7 @@ public class CustomWebsocketInterceptor implements ChannelInterceptor {
 
         if (command == CONNECT) {
             isValid(roomStatus, roomId, userId);
-            roomService.enterRoom(roomId);
+            roomService.enterRoom(roomId,userId);
         }
 
         return message;

--- a/src/main/java/com/example/MnM/base/exception/ChatControllerAdvice.java
+++ b/src/main/java/com/example/MnM/base/exception/ChatControllerAdvice.java
@@ -15,4 +15,9 @@ public class ChatControllerAdvice {
     public String notFoundRoomException(NotFoundRoomException e) {
         return rq.historyBack(e.getMessage());
     }
+
+    @ExceptionHandler(OverCapacityRoomException.class)
+    public String overCapacityRoomException(OverCapacityRoomException e) {
+        return rq.historyBack(e.getMessage());
+    }
 }

--- a/src/main/java/com/example/MnM/base/exception/NotFoundParticipantException.java
+++ b/src/main/java/com/example/MnM/base/exception/NotFoundParticipantException.java
@@ -1,0 +1,19 @@
+package com.example.MnM.base.exception;
+
+public class NotFoundParticipantException extends RuntimeException {
+    public NotFoundParticipantException() {
+        super();
+    }
+
+    public NotFoundParticipantException(String message) {
+        super(message);
+    }
+
+    public NotFoundParticipantException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotFoundParticipantException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/example/MnM/base/exception/NotRoomParticipants.java
+++ b/src/main/java/com/example/MnM/base/exception/NotRoomParticipants.java
@@ -1,0 +1,20 @@
+package com.example.MnM.base.exception;
+
+public class NotRoomParticipants extends RuntimeException {
+
+    public NotRoomParticipants() {
+        super();
+    }
+
+    public NotRoomParticipants(String message) {
+        super(message);
+    }
+
+    public NotRoomParticipants(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotRoomParticipants(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/example/MnM/base/exception/OverCapacityRoomException.java
+++ b/src/main/java/com/example/MnM/base/exception/OverCapacityRoomException.java
@@ -1,0 +1,19 @@
+package com.example.MnM.base.exception;
+
+public class OverCapacityRoomException extends RuntimeException {
+    public OverCapacityRoomException() {
+        super();
+    }
+
+    public OverCapacityRoomException(String message) {
+        super(message);
+    }
+
+    public OverCapacityRoomException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public OverCapacityRoomException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/example/MnM/boundedContext/chat/controller/MessageController.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/controller/MessageController.java
@@ -30,7 +30,9 @@ public class MessageController {
 
         switch (messageDto.getStatus()) {
             case EXIT -> {
-                return isRoomOwnerExit(messageDto) ? deleteRoom(messageDto) : messageDto;
+                if (isRoomOwnerExit(messageDto))
+                    return deleteRoom(messageDto);
+                roomService.exitRoom(messageDto.getRoomId());
             }
             case SEND -> {
                 chatService.saveChatToCache(roomId, messageDto);

--- a/src/main/java/com/example/MnM/boundedContext/chat/controller/MessageController.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/controller/MessageController.java
@@ -35,6 +35,7 @@ public class MessageController {
                 roomService.exitRoom(messageDto.getRoomId(), String.valueOf(messageDto.getSenderId()));
             }
             case SEND -> {
+                roomService.isRoomMember(roomId,messageDto.getSenderId());
                 chatService.saveChatToCache(roomId, messageDto);
             }
         }

--- a/src/main/java/com/example/MnM/boundedContext/chat/controller/MessageController.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/controller/MessageController.java
@@ -32,7 +32,7 @@ public class MessageController {
             case EXIT -> {
                 if (isRoomOwnerExit(messageDto))
                     return deleteRoom(messageDto);
-                roomService.exitRoom(messageDto.getRoomId());
+                roomService.exitRoom(messageDto.getRoomId(), String.valueOf(messageDto.getSenderId()));
             }
             case SEND -> {
                 chatService.saveChatToCache(roomId, messageDto);

--- a/src/main/java/com/example/MnM/boundedContext/chat/controller/MessageController.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/controller/MessageController.java
@@ -1,10 +1,10 @@
 package com.example.MnM.boundedContext.chat.controller;
 
 import com.example.MnM.boundedContext.chat.dto.ChatMessageDto;
-import com.example.MnM.boundedContext.chat.dto.DeleteRoomDto;
+import com.example.MnM.boundedContext.room.dto.DeleteRoomDto;
 import com.example.MnM.boundedContext.chat.entity.ChatStatus;
 import com.example.MnM.boundedContext.chat.service.ChatService;
-import com.example.MnM.boundedContext.chat.service.RoomService;
+import com.example.MnM.boundedContext.room.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;

--- a/src/main/java/com/example/MnM/boundedContext/chat/controller/MessageController.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/controller/MessageController.java
@@ -30,14 +30,14 @@ public class MessageController {
 
         switch (messageDto.getStatus()) {
             case EXIT -> {
+
                 if (isRoomOwnerExit(messageDto)) {
                     return finishChat(messageDto);
                 }
 
-//                roomService.exitRoom(messageDto.getRoomId(), String.valueOf(messageDto.getSenderId()));
             }
             case SEND -> {
-                roomService.isRoomMember(roomId,messageDto.getSenderId());
+                roomService.isRoomMember(roomId, messageDto.getSenderId());
                 chatService.saveChatToCache(roomId, messageDto);
             }
         }
@@ -50,7 +50,9 @@ public class MessageController {
 
         chatService.saveChatToCache(roomId, messageDto);
 
-        return isRoomOwnerExit(messageDto) ? finishChat(messageDto) : messageDto;
+        Long exitRoom = roomService.exitRoom(messageDto.getRoomId(), String.valueOf(messageDto.getSenderId()));
+
+        return isRoomOwnerExit(messageDto) || exitRoom == 0L ? finishChat(messageDto) : messageDto;
     }
 
     private boolean isRoomOwnerExit(ChatMessageDto messageDto) {

--- a/src/main/java/com/example/MnM/boundedContext/chat/controller/RoomController.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/controller/RoomController.java
@@ -55,21 +55,4 @@ public class RoomController {
         return "chat/room";
     }
 
-    @DeleteMapping("/room/delete")
-    public ResponseEntity<String> deleteRoom(DeleteRoomDto deleteRoomDto) {
-
-        Long memberId = rq.getMember().getId();
-
-        if (!isRoomOwner(deleteRoomDto, memberId)) {
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        return new ResponseEntity<>(HttpStatus.OK);
-    }
-
-    private boolean isRoomOwner(DeleteRoomDto deleteRoomDto, Long memberId) {
-        return deleteRoomDto.getUserId().equals(memberId);
-    }
-
-
 }

--- a/src/main/java/com/example/MnM/boundedContext/chat/dto/SaveChatDto.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/dto/SaveChatDto.java
@@ -8,6 +8,5 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public class SaveChatDto {
-    private final String roomId;
     private final String roomSecretId;
 }

--- a/src/main/java/com/example/MnM/boundedContext/chat/dto/SentimentDto.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/dto/SentimentDto.java
@@ -1,0 +1,4 @@
+package com.example.MnM.boundedContext.chat.dto;
+
+public record SentimentDto(float magnitude, float score) {
+}

--- a/src/main/java/com/example/MnM/boundedContext/chat/entity/EmotionDegree.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/entity/EmotionDegree.java
@@ -1,28 +1,17 @@
 package com.example.MnM.boundedContext.chat.entity;
 
-import com.example.MnM.base.baseEntity.BaseEntity;
-import com.example.MnM.boundedContext.member.entity.Member;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Embeddable;
 import lombok.*;
 
-
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EqualsAndHashCode
 @Getter
-@Entity
-public class EmotionDegree extends BaseEntity {
+@Embeddable
+public class EmotionDegree {
 
-    private String tendency;
     private float magnitude;
     private float score;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Member member;
-
-    public EmotionDegree(String tendency,float magnitude, float score) {
-        this.tendency =tendency;
-        this.magnitude = magnitude;
-        this.score = score;
-    }
+    private String mbti;
 }
+

--- a/src/main/java/com/example/MnM/boundedContext/chat/entity/EmotionDegree.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/entity/EmotionDegree.java
@@ -1,7 +1,10 @@
 package com.example.MnM.boundedContext.chat.entity;
 
 import com.example.MnM.base.baseEntity.BaseEntity;
+import com.example.MnM.boundedContext.member.entity.Member;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
 import lombok.*;
 
 
@@ -13,6 +16,9 @@ public class EmotionDegree extends BaseEntity {
     private String tendency;
     private float magnitude;
     private float score;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
 
     public EmotionDegree(String tendency,float magnitude, float score) {
         this.tendency =tendency;

--- a/src/main/java/com/example/MnM/boundedContext/chat/entity/RedisChat.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/entity/RedisChat.java
@@ -1,0 +1,9 @@
+package com.example.MnM.boundedContext.chat.entity;
+
+public enum RedisChat {
+    CHAT;
+
+    public String getKey(String roomSecretId) {
+        return "%s:%s".formatted(this.name(), roomSecretId);
+    }
+}

--- a/src/main/java/com/example/MnM/boundedContext/chat/entity/RoomStatus.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/entity/RoomStatus.java
@@ -1,5 +1,0 @@
-package com.example.MnM.boundedContext.chat.entity;
-
-public enum RoomStatus {
-    SINGLE, GROUP
-}

--- a/src/main/java/com/example/MnM/boundedContext/chat/event/ChatEventListener.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/event/ChatEventListener.java
@@ -19,7 +19,7 @@ public class ChatEventListener {
     private final ChatService chatService;
 
     @Async("messageThreadPool")
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     @EventListener(SaveChatDto.class)
     public void saveChatToDb(SaveChatDto saveChatDto) {
 

--- a/src/main/java/com/example/MnM/boundedContext/chat/event/ChatEventListener.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/event/ChatEventListener.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -23,10 +22,9 @@ public class ChatEventListener {
     @EventListener(SaveChatDto.class)
     public void saveChatToDb(SaveChatDto saveChatDto) {
 
-        String roomId = saveChatDto.getRoomId();
         String roomSecretId = saveChatDto.getRoomSecretId();
 
-        chatService.saveChatToDb(roomSecretId, roomId);
+        chatService.saveChatToDb(roomSecretId);
         chatService.deleteCacheChat(roomSecretId);
     }
 }

--- a/src/main/java/com/example/MnM/boundedContext/chat/infra/GoogleSentimentService.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/infra/GoogleSentimentService.java
@@ -1,6 +1,6 @@
 package com.example.MnM.boundedContext.chat.infra;
 
-import com.example.MnM.boundedContext.chat.entity.EmotionDegree;
+import com.example.MnM.boundedContext.chat.dto.SentimentDto;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.language.v1.*;
@@ -23,7 +23,7 @@ public class GoogleSentimentService implements InspectSentimentService {
     private String keyPath;
 
     @Async("googleService")
-    public CompletableFuture<EmotionDegree> chatInspectSentiment(String tendency, String msg) throws IOException {
+    public CompletableFuture<SentimentDto> chatInspectSentiment(String msg) throws IOException {
 
         GoogleCredentials credentials = GoogleCredentials.fromStream(new FileInputStream(keyPath));
 
@@ -36,11 +36,10 @@ public class GoogleSentimentService implements InspectSentimentService {
             Sentiment sentiment = response.getDocumentSentiment();
 
             if (sentiment == null) {
-                log.info("No sentiment found");
+                log.debug("No sentiment found");
             }
 
-            EmotionDegree emotionDegree = new EmotionDegree(tendency,sentiment.getMagnitude(), sentiment.getScore());
-            return CompletableFuture.completedFuture(emotionDegree);
+            return CompletableFuture.completedFuture(new SentimentDto(sentiment.getMagnitude(), sentiment.getScore()));
         }
     }
 }

--- a/src/main/java/com/example/MnM/boundedContext/chat/infra/InspectSentimentService.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/infra/InspectSentimentService.java
@@ -1,5 +1,6 @@
 package com.example.MnM.boundedContext.chat.infra;
 
+import com.example.MnM.boundedContext.chat.dto.SentimentDto;
 import com.example.MnM.boundedContext.chat.entity.EmotionDegree;
 
 import java.io.IOException;
@@ -7,5 +8,5 @@ import java.util.concurrent.CompletableFuture;
 
 public interface InspectSentimentService {
 
-    CompletableFuture<EmotionDegree> chatInspectSentiment(String tendency,String msg) throws IOException;
+    CompletableFuture<SentimentDto> chatInspectSentiment(String msg) throws IOException;
 }

--- a/src/main/java/com/example/MnM/boundedContext/chat/infra/LocalInspectService.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/infra/LocalInspectService.java
@@ -1,12 +1,14 @@
 package com.example.MnM.boundedContext.chat.infra;
 
 import com.example.MnM.boundedContext.chat.entity.EmotionDegree;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 
+@Slf4j
 @Component
 @Profile({"dev","test"})
 public class LocalInspectService implements InspectSentimentService {
@@ -14,7 +16,7 @@ public class LocalInspectService implements InspectSentimentService {
     public CompletableFuture<EmotionDegree> chatInspectSentiment(String tendency, String msg) {
 
         Random random = new Random();
-
+        log.info("LocalInspectService 호출 = {}",msg);
         return CompletableFuture.completedFuture(new EmotionDegree(tendency,random.nextFloat(), random.nextFloat()));
     }
 }

--- a/src/main/java/com/example/MnM/boundedContext/chat/infra/LocalInspectService.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/infra/LocalInspectService.java
@@ -1,6 +1,6 @@
 package com.example.MnM.boundedContext.chat.infra;
 
-import com.example.MnM.boundedContext.chat.entity.EmotionDegree;
+import com.example.MnM.boundedContext.chat.dto.SentimentDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -13,10 +13,10 @@ import java.util.concurrent.CompletableFuture;
 @Profile({"dev","test"})
 public class LocalInspectService implements InspectSentimentService {
     @Override
-    public CompletableFuture<EmotionDegree> chatInspectSentiment(String tendency, String msg) {
+    public CompletableFuture<SentimentDto> chatInspectSentiment(String msg) {
 
         Random random = new Random();
         log.info("LocalInspectService 호출 = {}",msg);
-        return CompletableFuture.completedFuture(new EmotionDegree(tendency,random.nextFloat(), random.nextFloat()));
+        return CompletableFuture.completedFuture(new SentimentDto(random.nextFloat(), random.nextFloat()));
     }
 }

--- a/src/main/java/com/example/MnM/boundedContext/chat/repository/EmotionRepository.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/repository/EmotionRepository.java
@@ -1,0 +1,7 @@
+package com.example.MnM.boundedContext.chat.repository;
+
+import com.example.MnM.boundedContext.chat.entity.EmotionDegree;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmotionRepository extends JpaRepository<EmotionDegree, Long> {
+}

--- a/src/main/java/com/example/MnM/boundedContext/chat/repository/EmotionRepository.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/repository/EmotionRepository.java
@@ -1,7 +1,0 @@
-package com.example.MnM.boundedContext.chat.repository;
-
-import com.example.MnM.boundedContext.chat.entity.EmotionDegree;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface EmotionRepository extends JpaRepository<EmotionDegree, Long> {
-}

--- a/src/main/java/com/example/MnM/boundedContext/chat/service/ChatService.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/service/ChatService.java
@@ -2,16 +2,23 @@ package com.example.MnM.boundedContext.chat.service;
 
 import com.example.MnM.boundedContext.chat.dto.ChatMessageDto;
 import com.example.MnM.boundedContext.chat.entity.ChatMessage;
+import com.example.MnM.boundedContext.chat.entity.EmotionDegree;
+import com.example.MnM.boundedContext.chat.infra.InspectSentimentService;
 import com.example.MnM.boundedContext.chat.repository.ChatRepository;
+import com.example.MnM.boundedContext.chat.repository.EmotionRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @RequiredArgsConstructor
 @Transactional
 @Service
@@ -19,6 +26,8 @@ public class ChatService {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final ChatRepository chatRepository;
+    private final EmotionRepository emotionRepository;
+    private final InspectSentimentService inspectSentimentService;
 
     public void saveChatToCache(String roomId, ChatMessageDto messageDto) {
         redisTemplate.opsForList().rightPush(roomId, messageDto);
@@ -28,19 +37,32 @@ public class ChatService {
     public void saveChatToDb(String roomSecretId, String roomId) {
         List<Object> list = redisTemplate.opsForList().range(roomSecretId, 0, -1);
 
-        List<ChatMessage> entities = new ArrayList<>();
+        StringBuilder sb = new StringBuilder();
 
-        //TODO 감정 분석
+        List<ChatMessage> entities = new ArrayList<>();
 
         for (Object dto : list) {
             ChatMessageDto messageDto = (ChatMessageDto) dto;
-            ChatMessage message = ChatMessage.builder()
-                    .message(messageDto.getMessage())
-                    .writer(messageDto.getSender())
+            String message = messageDto.getMessage();
+            String sender = messageDto.getSender();
+
+            ChatMessage chatMessage = ChatMessage.builder()
+                    .message(message)
+                    .writer(sender)
                     .writerId(messageDto.getSenderId())
                     .roomId(roomId)
                     .build();
-            entities.add(message);
+            entities.add(chatMessage);
+
+            sb.append(sender).append(": ").append(message).append("\n");
+        }
+
+        try {
+            inspectSentimentService.chatInspectSentiment("hello",sb.toString())
+                    .thenApplyAsync(emotionRepository::save);
+        } catch (IOException e) {
+            log.error("inspectSentimentService error",e);
+            throw new RuntimeException(e);
         }
 
         chatRepository.saveAll(entities);

--- a/src/main/java/com/example/MnM/boundedContext/chat/service/ChatService.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/service/ChatService.java
@@ -2,25 +2,20 @@ package com.example.MnM.boundedContext.chat.service;
 
 import com.example.MnM.boundedContext.chat.dto.ChatMessageDto;
 import com.example.MnM.boundedContext.chat.entity.ChatMessage;
-import com.example.MnM.boundedContext.chat.entity.EmotionDegree;
-import com.example.MnM.boundedContext.chat.entity.RedisChat;
-import com.example.MnM.boundedContext.chat.infra.InspectSentimentService;
 import com.example.MnM.boundedContext.chat.repository.ChatRepository;
-import com.example.MnM.boundedContext.chat.repository.EmotionRepository;
-import com.example.MnM.boundedContext.member.repository.MemberRepository;
+import com.example.MnM.boundedContext.room.dto.DeleteRoomDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import static com.example.MnM.boundedContext.chat.entity.RedisChat.*;
+import static com.example.MnM.boundedContext.chat.entity.RedisChat.CHAT;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -30,15 +25,16 @@ public class ChatService {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final ChatRepository chatRepository;
-    private final EmotionRepository emotionRepository;
-    private final InspectSentimentService inspectSentimentService;
+    private final FacadeChatService facadeChatService;
+    private final ApplicationEventPublisher publisher;
 
     public void saveChatToCache(String roomSecretId, ChatMessageDto messageDto) {
         redisTemplate.opsForList().rightPush(CHAT.getKey(roomSecretId), messageDto);
         redisTemplate.expire(roomSecretId, 3, TimeUnit.DAYS);
     }
 
-    public void saveChatToDb(String roomSecretId, String roomId) {
+    public void saveChatToDb(String roomSecretId ) {
+
         List<Object> list = redisTemplate.opsForList().range(CHAT.getKey(roomSecretId), 0, -1);
 
         StringBuilder sb = new StringBuilder();
@@ -54,20 +50,14 @@ public class ChatService {
                     .message(message)
                     .writer(sender)
                     .writerId(messageDto.getSenderId())
-                    .roomId(roomId)
+                    .roomId(roomSecretId)
                     .build();
             entities.add(chatMessage);
 
             sb.append(sender).append(": ").append(message).append("\n");
         }
+        facadeChatService.inspectChat(roomSecretId,sb.toString());
 
-        try {
-            inspectSentimentService.chatInspectSentiment("hello",sb.toString())
-                    .thenApplyAsync(emotionRepository::save);
-        } catch (IOException e) {
-            log.error("inspectSentimentService error",e);
-            throw new RuntimeException(e);
-        }
         redisTemplate.delete(CHAT.getKey(roomSecretId));
 
         chatRepository.saveAll(entities);
@@ -76,6 +66,7 @@ public class ChatService {
 
 
     public void deleteCacheChat(String roomId) {
-        redisTemplate.delete(roomId);
+        redisTemplate.delete(CHAT.getKey(roomId));
+        publisher.publishEvent(new DeleteRoomDto(roomId));
     }
 }

--- a/src/main/java/com/example/MnM/boundedContext/chat/service/FacadeChatService.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/service/FacadeChatService.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static com.example.MnM.boundedContext.room.entity.RedisRoom.COUNT;
 
 
-/**
+/*
  * Single 전용 객체입니다.
  */
 @Slf4j
@@ -32,12 +32,7 @@ public class FacadeChatService {
 
     public void inspectChat(String roomSecretId, String chat) {
 
-        SetOperations<String, Object> redisSet = redisTemplate.opsForSet();
-
-        if (redisSet.size(COUNT.getKey(roomSecretId)) <= 1)
-            return;
-
-        List<String> values = redisSet
+        List<String> values = redisTemplate.opsForSet()
                 .members(COUNT.getKey(roomSecretId))
                 .stream()
                 .limit(2)

--- a/src/main/java/com/example/MnM/boundedContext/chat/service/FacadeChatService.java
+++ b/src/main/java/com/example/MnM/boundedContext/chat/service/FacadeChatService.java
@@ -1,0 +1,70 @@
+package com.example.MnM.boundedContext.chat.service;
+
+import com.example.MnM.base.exception.NotFoundParticipantException;
+import com.example.MnM.boundedContext.chat.infra.InspectSentimentService;
+import com.example.MnM.boundedContext.member.entity.Member;
+import com.example.MnM.boundedContext.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.example.MnM.boundedContext.room.entity.RedisRoom.COUNT;
+
+
+/**
+ * Single 전용 객체입니다.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class FacadeChatService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final InspectSentimentService inspectSentimentService;
+    private final MemberRepository memberRepository;
+    private final TransactionTemplate transactionTemplate;
+
+    public void inspectChat(String roomSecretId, String chat) {
+
+        SetOperations<String, Object> redisSet = redisTemplate.opsForSet();
+
+        if (redisSet.size(COUNT.getKey(roomSecretId)) <= 1)
+            return;
+
+        List<String> values = redisSet
+                .members(COUNT.getKey(roomSecretId))
+                .stream()
+                .limit(2)
+                .map(Object::toString)
+                .toList();
+
+        Long firstPerson = Long.parseLong(values.get(0));
+        Long secondPerson = Long.parseLong(values.get(1));
+
+        try {
+            inspectSentimentService.chatInspectSentiment(chat)
+                    .thenAccept((emotionDegree) -> {
+                        transactionTemplate.executeWithoutResult((status) -> {
+
+                            Member first = memberRepository.findById(firstPerson)
+                                    .orElseThrow(() -> new NotFoundParticipantException("존재 하지 않는 유저입니다."));
+                            Member second = memberRepository.findById(secondPerson)
+                                    .orElseThrow(() -> new NotFoundParticipantException("존재 하지 않는 유저입니다."));
+
+                            first.addBestEmotion(emotionDegree, second.getMbti());
+                            second.addBestEmotion(emotionDegree, first.getMbti());
+                        });
+                    });
+        } catch (IOException e) {
+            log.error("inspectSentimentService error", e);
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/src/main/java/com/example/MnM/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.example.MnM.boundedContext.member.entity;
 
 import com.example.MnM.base.baseEntity.BaseEntity;
+import com.example.MnM.boundedContext.chat.entity.EmotionDegree;
 import com.example.MnM.boundedContext.likeablePerson.entity.LikeablePerson;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
@@ -47,6 +48,9 @@ public class Member extends BaseEntity {
     private String profileImage; //프로필사진, 임시로 만듬
     private String introduce; //자기소개
 
+    @Builder.Default
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "member",cascade = CascadeType.ALL,orphanRemoval = true)
+    private Set<EmotionDegree> bestMatch = new HashSet<>();
 
 
     public Member(String userId, String username, String password) {

--- a/src/main/java/com/example/MnM/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/entity/Member.java
@@ -1,12 +1,13 @@
 package com.example.MnM.boundedContext.member.entity;
 
 import com.example.MnM.base.baseEntity.BaseEntity;
+import com.example.MnM.boundedContext.chat.dto.SentimentDto;
 import com.example.MnM.boundedContext.chat.entity.EmotionDegree;
 import com.example.MnM.boundedContext.likeablePerson.entity.LikeablePerson;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
-import lombok.Builder;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -16,8 +17,10 @@ import org.hibernate.annotations.SQLDelete;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 
 @Entity
@@ -49,14 +52,15 @@ public class Member extends BaseEntity {
     private String introduce; //자기소개
 
     @Builder.Default
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "member",cascade = CascadeType.ALL,orphanRemoval = true)
+    @ElementCollection
+    @CollectionTable(name = "bestMatch", joinColumns = @JoinColumn(name = "member_id"))
     private Set<EmotionDegree> bestMatch = new HashSet<>();
 
 
     public Member(String userId, String username, String password) {
         this.username = userId;
         this.name = username;
-        this.password =password;
+        this.password = password;
     }
 
 
@@ -71,8 +75,6 @@ public class Member extends BaseEntity {
 
         return grantedAuthorities;
     }
-
-
 
 
     @OneToMany(mappedBy = "fromMember", cascade = {CascadeType.ALL})
@@ -97,5 +99,9 @@ public class Member extends BaseEntity {
 
     public void changeUsername(String username) {
         this.username = username;
+    }
+
+    public void addBestEmotion(SentimentDto sentimentDto, String mbti) {
+        this.bestMatch.add(new EmotionDegree(sentimentDto.magnitude(),sentimentDto.score(),mbti));
     }
 }

--- a/src/main/java/com/example/MnM/boundedContext/room/controller/RoomController.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/controller/RoomController.java
@@ -1,13 +1,12 @@
-package com.example.MnM.boundedContext.chat.controller;
+package com.example.MnM.boundedContext.room.controller;
 
 import com.example.MnM.base.rq.Rq;
-import com.example.MnM.boundedContext.chat.dto.DeleteRoomDto;
-import com.example.MnM.boundedContext.chat.entity.ChatRoom;
-import com.example.MnM.boundedContext.chat.entity.RoomStatus;
-import com.example.MnM.boundedContext.chat.service.RoomService;
+import com.example.MnM.boundedContext.room.dto.EnterRoomDto;
+import com.example.MnM.boundedContext.room.entity.ChatRoom;
+import com.example.MnM.boundedContext.room.entity.RoomStatus;
+import com.example.MnM.boundedContext.room.service.RoomService;
+import com.example.MnM.boundedContext.member.entity.Member;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -50,7 +49,13 @@ public class RoomController {
     public String entranceRoom(Model model, @PathVariable String roomId) {
 
         ChatRoom room = roomService.findBySecretId(roomId);
+
+        Member member = rq.getMember();
+        EnterRoomDto enterRoomDto = new EnterRoomDto(member.getUsername(), member.getId());
+
         model.addAttribute("room",room);
+        model.addAttribute("enterPerson",enterRoomDto);
+
 
         return "chat/room";
     }

--- a/src/main/java/com/example/MnM/boundedContext/room/dto/ChatRoomDto.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/dto/ChatRoomDto.java
@@ -1,6 +1,6 @@
-package com.example.MnM.boundedContext.chat.dto;
+package com.example.MnM.boundedContext.room.dto;
 
-import com.example.MnM.boundedContext.chat.entity.RoomStatus;
+import com.example.MnM.boundedContext.room.entity.RoomStatus;
 import lombok.*;
 
 @EqualsAndHashCode

--- a/src/main/java/com/example/MnM/boundedContext/room/dto/DeleteRoomDto.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/dto/DeleteRoomDto.java
@@ -1,4 +1,4 @@
-package com.example.MnM.boundedContext.chat.dto;
+package com.example.MnM.boundedContext.room.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/com/example/MnM/boundedContext/room/dto/DeleteRoomDto.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/dto/DeleteRoomDto.java
@@ -10,7 +10,5 @@ import lombok.Getter;
 public class DeleteRoomDto {
 
     private String roomId;
-    private String username;
-    private Long userId;
 
 }

--- a/src/main/java/com/example/MnM/boundedContext/room/dto/EnterRoomDto.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/dto/EnterRoomDto.java
@@ -1,0 +1,13 @@
+package com.example.MnM.boundedContext.room.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode
+@AllArgsConstructor
+@Getter
+public class EnterRoomDto {
+    private String username;
+    private Long userId;
+}

--- a/src/main/java/com/example/MnM/boundedContext/room/entity/ChatRoom.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/entity/ChatRoom.java
@@ -1,4 +1,4 @@
-package com.example.MnM.boundedContext.chat.entity;
+package com.example.MnM.boundedContext.room.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/example/MnM/boundedContext/room/entity/RedisRoom.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/entity/RedisRoom.java
@@ -1,0 +1,9 @@
+package com.example.MnM.boundedContext.room.entity;
+
+public enum RedisRoom {
+    COUNT;
+
+    public String getKey(String roomSecretId) {
+        return "%s:%s".formatted(this.name(), roomSecretId);
+    }
+}

--- a/src/main/java/com/example/MnM/boundedContext/room/entity/RoomStatus.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/entity/RoomStatus.java
@@ -1,0 +1,5 @@
+package com.example.MnM.boundedContext.room.entity;
+
+public enum RoomStatus {
+    SINGLE, GROUP
+}

--- a/src/main/java/com/example/MnM/boundedContext/room/event/RoomEventListener.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/event/RoomEventListener.java
@@ -14,9 +14,7 @@ public class RoomEventListener {
 
     @EventListener(DeleteRoomDto.class)
     public void deleteRoomEvent(DeleteRoomDto dto) {
-
         String roomId = dto.getRoomId();
         roomService.deleteRoom(roomId);
-
     }
 }

--- a/src/main/java/com/example/MnM/boundedContext/room/event/RoomEventListener.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/event/RoomEventListener.java
@@ -1,7 +1,7 @@
-package com.example.MnM.boundedContext.chat.event;
+package com.example.MnM.boundedContext.room.event;
 
-import com.example.MnM.boundedContext.chat.dto.DeleteRoomDto;
-import com.example.MnM.boundedContext.chat.service.RoomService;
+import com.example.MnM.boundedContext.room.dto.DeleteRoomDto;
+import com.example.MnM.boundedContext.room.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/example/MnM/boundedContext/room/repository/RoomRepository.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/repository/RoomRepository.java
@@ -1,6 +1,6 @@
-package com.example.MnM.boundedContext.chat.repository;
+package com.example.MnM.boundedContext.room.repository;
 
-import com.example.MnM.boundedContext.chat.entity.ChatRoom;
+import com.example.MnM.boundedContext.room.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/example/MnM/boundedContext/room/service/RoomService.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/service/RoomService.java
@@ -1,10 +1,10 @@
-package com.example.MnM.boundedContext.chat.service;
+package com.example.MnM.boundedContext.room.service;
 
 import com.example.MnM.base.exception.NotFoundRoomException;
 import com.example.MnM.boundedContext.chat.dto.SaveChatDto;
-import com.example.MnM.boundedContext.chat.entity.ChatRoom;
-import com.example.MnM.boundedContext.chat.entity.RoomStatus;
-import com.example.MnM.boundedContext.chat.repository.RoomRepository;
+import com.example.MnM.boundedContext.room.entity.ChatRoom;
+import com.example.MnM.boundedContext.room.entity.RoomStatus;
+import com.example.MnM.boundedContext.room.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -72,5 +72,13 @@ public class RoomService {
     public boolean isRoomOwner(String roomId, Long userId) {
         ChatRoom chatRoom = findBySecretId(roomId);
         return chatRoom.getCreateUserId().equals(userId);
+    }
+
+    public void checkSingleRoom(String userId) {
+        //TODO Single check
+    }
+
+    public void checkGroupRoom(String roomId) {
+        //TODO Group check
     }
 }

--- a/src/main/java/com/example/MnM/boundedContext/room/service/RoomService.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/service/RoomService.java
@@ -3,12 +3,10 @@ package com.example.MnM.boundedContext.room.service;
 import com.example.MnM.base.exception.NotFoundRoomException;
 import com.example.MnM.base.exception.NotRoomParticipants;
 import com.example.MnM.base.exception.OverCapacityRoomException;
-import com.example.MnM.boundedContext.chat.dto.SaveChatDto;
 import com.example.MnM.boundedContext.room.entity.ChatRoom;
 import com.example.MnM.boundedContext.room.entity.RoomStatus;
 import com.example.MnM.boundedContext.room.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +23,6 @@ public class RoomService {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final RoomRepository roomRepository;
-    private final ApplicationEventPublisher publisher;
 
     private final Long MAX_CAPACITY = 10L;
 
@@ -50,24 +47,20 @@ public class RoomService {
         ChatRoom room = roomRepository.findBySecretId(roomSecretId)
                 .orElseThrow(() -> new NotFoundRoomException("방을 찾을 수 없습니다."));
 
-        Long roomId = room.getId();
         roomRepository.delete(room);
-
         redisTemplate.delete(COUNT.getKey(roomSecretId));
-
-        publisher.publishEvent(new SaveChatDto(String.valueOf(roomId), roomSecretId));
     }
 
     @Transactional
-    public Long enterRoom(String roomSecretId,String userId) {
+    public Long enterRoom(String roomSecretId, String userId) {
         isExistRoom(roomSecretId);
-        return redisTemplate.opsForSet().add(COUNT.getKey(roomSecretId),userId);
+        return redisTemplate.opsForSet().add(COUNT.getKey(roomSecretId), userId);
     }
 
     @Transactional
-    public Long exitRoom(String roomSecretId,String userId) {
+    public Long exitRoom(String roomSecretId, String userId) {
         isExistRoom(roomSecretId);
-        return redisTemplate.opsForSet().remove(COUNT.getKey(roomSecretId),userId);
+        return redisTemplate.opsForSet().remove(COUNT.getKey(roomSecretId), userId);
     }
 
     private void isExistRoom(String roomSecretId) {
@@ -110,7 +103,7 @@ public class RoomService {
     }
 
     public void isRoomMember(String roomSecretId, Long senderId) {
-        if (Boolean.FALSE.equals(redisTemplate.opsForSet().isMember(COUNT.getKey(roomSecretId), senderId)))
+        if (Boolean.FALSE.equals(redisTemplate.opsForSet().isMember(COUNT.getKey(roomSecretId), String.valueOf(senderId))))
             throw new NotRoomParticipants("이 방의 참여자가 아닙니다.");
     }
 }

--- a/src/main/java/com/example/MnM/boundedContext/room/service/RoomService.java
+++ b/src/main/java/com/example/MnM/boundedContext/room/service/RoomService.java
@@ -24,7 +24,7 @@ public class RoomService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final RoomRepository roomRepository;
 
-    private final Long MAX_CAPACITY = 10L;
+    private static final Long MAX_CAPACITY = 10L;
 
     @Transactional
     public String createRoom(Long memberId, String username, RoomStatus status) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,9 +4,9 @@ spring:
     include: secret
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mariadb://127.0.0.1:3307/MnM__dev?useUnicode=true&characterEncoding=utf8&autoReconnect=true&serverTimezone=Asia/Seoul
-    username: root
-    password:
+    url: ENC(caq/+9P8gm2xwvxAc6bryGylgJEX19QHmuL3umll+NyiG7ggOoug5uWyGDTQzBd1YG4YpRK/PVvYFt2zHM0bYrLSPIg4kIo3fpJFJnlWD3bzjY1UXSuTBuhLM3r4JgfuRlsfAb9tWG7E+KSIe1HQWedUAT4vbT9IYxskAIZVkCFqWIS8v3EChQ==)
+    username: ENC(feciTQh5rLQ2dmTa1Z/A9g==)
+    password: ENC(lZ30TkUte7l7K/5PAiHp3g==)
 
   jpa:
     hibernate:
@@ -37,3 +37,8 @@ custom:
   cookie:
     tokenValiditySeconds: '#{60 * 60 * 24 * 3}'
     key: "12345678"
+
+
+jasypt:
+  encryptor:
+    bean: jasyptStringEncryptor

--- a/src/main/resources/static/js/room.js
+++ b/src/main/resources/static/js/room.js
@@ -24,10 +24,6 @@ stompClient.connect(headers, function (frame) {
     }, headers);
     sendMessage(`${username}님이 입장하셨습니다.`, "ENTER");
 
-    stompClient.onDisconnect = function () {
-        exitRoom();
-        window.location.href = 'http://localhost:8080/chat/rooms'; // 자동으로 이동할 URL
-    };
     // Send 버튼 이벤트
     sendButton.addEventListener('click', function () {
         sendMessage(messageInput.value, "SEND");
@@ -43,7 +39,6 @@ stompClient.connect(headers, function (frame) {
 
     window.addEventListener("beforeunload", function (event) {
         exitRoom();
-        stompClient.disconnect();
     });
 });
 
@@ -59,15 +54,8 @@ function sendMessage(message, status) {
 }
 
 function showMessageOutput(messageData) {
-    if (messageData.status === "DELETE") {
-        stompClient.disconnect();
-        window.location.href = 'http://localhost:8080/chat/rooms'; // 홈으로 이동
-        return;
-    }
-
-    if (messageData.status === "EXIT" && messageData.sender === username) {
-        stompClient.disconnect();
-        window.location.href = 'http://localhost:8080/chat/rooms';
+    if (messageData.status === "DELETE" || (messageData.status === "EXIT" && messageData.sender === username)) {
+        exitRoom();
         return;
     }
 
@@ -165,12 +153,10 @@ document.addEventListener("DOMContentLoaded", function () {
         const modal = document.querySelector('#exit');
         modal.classList.add('hidden');
     });
-
-
 });
 
 function exitRoom() {
-
     sendMessage(`${username}님이 나갔습니다.`, "EXIT");
-
+    stompClient.disconnect();
+    window.location.href = 'http://localhost:8080/chat/rooms';
 }

--- a/src/main/resources/static/js/room.js
+++ b/src/main/resources/static/js/room.js
@@ -14,7 +14,8 @@ const sendButton = document.getElementById('sendButton');
 const headers = {
     'username': username,
     'roomId': roomId,
-    'userId': userId
+    'userId': userId,
+    'roomStatus':roomStatus
 };
 stompClient.connect(headers, function (frame) {
     // 구독 설정
@@ -23,6 +24,10 @@ stompClient.connect(headers, function (frame) {
     }, headers);
     sendMessage(`${username}님이 입장하셨습니다.`, "ENTER");
 
+    stompClient.onDisconnect = function () {
+        exitRoom();
+        window.location.href = 'http://localhost:8080/chat/rooms'; // 자동으로 이동할 URL
+    };
     // Send 버튼 이벤트
     sendButton.addEventListener('click', function () {
         sendMessage(messageInput.value, "SEND");
@@ -66,7 +71,6 @@ function showMessageOutput(messageData) {
         return;
     }
 
-
     // 메시지를 담을 chat-message div를 생성합니다.
     const messageElement = document.createElement('div');
     messageElement.classList.add('chat-message');
@@ -79,21 +83,34 @@ function showMessageOutput(messageData) {
     spanElement.classList.add('px-4', 'py-2', 'rounded-lg', 'inline-block');
 
     spanElement.textContent = messageData.message;
-    // <div className="w-6 h-6 rounded-full order-2">hello</div>
-    const senderElement = document.createElement('div');
+
+    const senderElement2 = document.createElement('div');
+    senderElement2.classList.add("flex", "items-center", "h-full");
+    const senderElement3 = document.createElement('div');
+    senderElement3.classList.add("flex-shrink-0", "truncate");
+    const senderElement = document.createElement('span');
     senderElement.textContent = messageData.sender;
-    senderElement.classList.add('w-6', 'h-6', 'rounded-full');
+    senderElement.classList.add('w-6', 'h-6', 'rounded-full','whitespace-nowrap');
+
+
+    senderElement2.appendChild(senderElement3);
+    senderElement3.appendChild(senderElement);
 
     if (messageData.status === "EXIT") {
         detailsElement.classList.add('flex', 'items-center', 'justify-center');
-        textElement.classList.add('bg-gray-300', 'text-gray-600');
+        textElement.classList.add('bg-pink-500', 'text-white');
+        spanElement.classList.add('rounded-lg');
+        senderElement.classList.add('hidden');
+    } else if (messageData.status === "ENTER") {
+        detailsElement.classList.add('flex', 'items-center', 'justify-center');
+        textElement.classList.add('bg-blue-500','text-white');
         spanElement.classList.add('rounded-lg');
         senderElement.classList.add('hidden');
     } else if (messageData.sender === username) {
         detailsElement.classList.add('flex', 'items-end', 'justify-end');
         textElement.classList.add('order-1', 'items-end');
         spanElement.classList.add('rounded-br-none', 'bg-blue-600', 'text-white');
-        senderElement.classList.add('order-2');
+        senderElement2.classList.add('order-2');
     } else {
         detailsElement.classList.add('flex', 'items-end');
         textElement.classList.add('order-2', 'items-start');
@@ -104,7 +121,7 @@ function showMessageOutput(messageData) {
     // 생성된 모든 요소를 조립합니다.
     textElement.appendChild(spanElement);
     detailsElement.appendChild(textElement);
-    detailsElement.appendChild(senderElement);
+    detailsElement.appendChild(senderElement2);
     messageElement.appendChild(detailsElement);
 
     // 완성된 메시지를 메시지 목록에 추가합니다.

--- a/src/main/resources/static/js/room.js
+++ b/src/main/resources/static/js/room.js
@@ -37,6 +37,7 @@ stompClient.connect(headers, function (frame) {
     });
 
     window.addEventListener("beforeunload", function (event) {
+        exitRoom();
         stompClient.disconnect();
     });
 });
@@ -56,6 +57,12 @@ function showMessageOutput(messageData) {
     if (messageData.status === "DELETE") {
         stompClient.disconnect();
         window.location.href = 'http://localhost:8080/chat/rooms'; // 홈으로 이동
+        return;
+    }
+
+    if (messageData.status === "EXIT" && messageData.sender === username) {
+        stompClient.disconnect();
+        window.location.href = 'http://localhost:8080/chat/rooms';
         return;
     }
 
@@ -142,26 +149,11 @@ document.addEventListener("DOMContentLoaded", function () {
         modal.classList.add('hidden');
     });
 
-    function exitRoom() {
-        let formData = new FormData();
 
-        formData.append("username", username);
-        formData.append("roomId", roomId);
-        formData.append("userId", userId);
-        const csrfToken = document.querySelector('meta[name="_csrf"]').getAttribute('content');
-        const csrfHeader = document.querySelector('meta[name="_csrf_header"]').getAttribute('content');
-
-        fetch("/chat/room/delete", {
-            method: "DELETE",
-            headers: {
-                [csrfHeader]: csrfToken
-            },
-            body: formData
-        }).then(r => {
-            if (r.status === 200) {
-                sendMessage(`${username}님이 나갔습니다.`, "EXIT");
-                window.location.href = 'http://localhost:8080/chat/rooms';
-            }
-        });
-    }
 });
+
+function exitRoom() {
+
+    sendMessage(`${username}님이 나갔습니다.`, "EXIT");
+
+}

--- a/src/main/resources/templates/chat/room.html
+++ b/src/main/resources/templates/chat/room.html
@@ -16,31 +16,7 @@
       </div>
     </div>
     <div id="messages" class="flex flex-col space-y-4 p-3 overflow-y-auto scrollbar-thumb-blue scrollbar-thumb-rounded scrollbar-track-blue-lighter scrollbar-w-2 scrolling-touch">
-      <div class="chat-message">
-        <div class="flex items-end">
-          <div class="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
-            <div><span class="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-300 text-gray-600">Thanks for your message David. I thought I'm alone with this issue. Please, ? the issue to support it :)</span></div>
-          </div>
-          <div class="flex items-center h-full">
-            <div class="flex-shrink-0 truncate">
-              <span class="whitespace-nowrap">yasasaou</span>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="chat-message">
-        <div class="flex items-end justify-end">
-          <div class="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
-            <div><span class="px-4 py-2 rounded-lg inline-block rounded-br-none bg-blue-600 text-white ">yes, I have a mac. I never had issues with root permission as well, but this helped me to solve the problem</span></div>
-          </div>
-            <div class="flex items-center h-full order-2">
-              <div class="flex-shrink-0 truncate">
-                <span class="whitespace-nowrap">hello world to good</span>
-              </div>
-            </div>
 
-        </div>
-      </div>
     </div>
     <div class="border-t-2 border-gray-200 px-4 pt-4 mb-2 sm:mb-0">
       <div class="relative flex">

--- a/src/main/resources/templates/chat/room.html
+++ b/src/main/resources/templates/chat/room.html
@@ -21,7 +21,11 @@
           <div class="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-start">
             <div><span class="px-4 py-2 rounded-lg inline-block rounded-bl-none bg-gray-300 text-gray-600">Thanks for your message David. I thought I'm alone with this issue. Please, ? the issue to support it :)</span></div>
           </div>
-          <div class="w-6 h-6 rounded-full order-1">you</div>
+          <div class="flex items-center h-full">
+            <div class="flex-shrink-0 truncate">
+              <span class="whitespace-nowrap">yasasaou</span>
+            </div>
+          </div>
         </div>
       </div>
       <div class="chat-message">
@@ -29,7 +33,12 @@
           <div class="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-1 items-end">
             <div><span class="px-4 py-2 rounded-lg inline-block rounded-br-none bg-blue-600 text-white ">yes, I have a mac. I never had issues with root permission as well, but this helped me to solve the problem</span></div>
           </div>
-          <div class="w-6 h-6 rounded-full order-2">hello</div>
+            <div class="flex items-center h-full order-2">
+              <div class="flex-shrink-0 truncate">
+                <span class="whitespace-nowrap">hello world to good</span>
+              </div>
+            </div>
+
         </div>
       </div>
     </div>
@@ -86,9 +95,10 @@
 
 
   <script th:inline="javascript">
-    const username = /*[[${room.createUser}]]*/ null;
-    const roomId = /*[[${room.secretId}]]*/ null;  // 채팅방 id는 여기에 할당하십시오.
-    const userId = /*[[${room.createUserId}]]*/ null;  // 채팅방 id는 여기에 할당하십시오.
+    const username = /*[[${enterPerson.username}]]*/ null;
+    const roomId = /*[[${room.secretId}]]*/ null;
+    const userId = /*[[${enterPerson.userId}]]*/ null;
+    const roomStatus = /*[[${room.status}]]*/ null;
     </script>
   <script th:src="@{/js/room.js}"></script>
 

--- a/src/main/resources/templates/chat/rooms.html
+++ b/src/main/resources/templates/chat/rooms.html
@@ -24,16 +24,16 @@
       </tr>
       </thead>
       <tbody>
-      <tr th:each="room, i : ${rooms}" th:class="${i.count % 2 == 1} ? 'bg-gray-300 dark:bg-gray-800 hover:bg-blue-200 dark:hover:bg-blue-900 text-black dark:text-white' :
-      'bg-white dark:bg-gray-800 hover:bg-blue-200 dark:hover:bg-blue-900 text-black dark:text-white'">
-        <th scope="row" th:text="${room.name}"
-            class="w-1/3 px-6 py-4 flex font-medium flex-grow flex-wrap text-gray-900 whitespace-nowrap dark:text-white text-center">
+      <tr th:each="room, i : ${rooms}" th:class="${i.count % 2 == 1} ? 'flex bg-gray-300 dark:bg-gray-800 hover:bg-blue-200 dark:hover:bg-blue-900 text-black dark:text-white' :
+      'flex bg-white dark:bg-gray-800 hover:bg-blue-200 dark:hover:bg-blue-900 text-black dark:text-white'">
+        <td th:text="${room.name}"
+            class="w-1/3 px-6 py-4 flex-grow flex items-center justify-center  text-gray-900 whitespace-nowrap dark:text-white text-center">
           roomName
-        </th>
-        <td class="px-6 py-4 text-center flex-grow" th:text="${room.createUser}">
+        </td>
+        <td class="w-1/3 px-6 py-4 flex-grow flex items-center justify-center text-center" th:text="${room.createUser}">
           createUser
         </td>
-        <td class="px-6 py-4 text-right text-center flex-grow">
+        <td class="w-1/3 px-6 py-4 flex-grow flex items-center justify-center text-right text-center">
           <a class="btn btn-primary" th:href="@{/chat/room/{id}(id=${room.getSecretId})}">[[${room.name}]]</a>
         </td>
       </tr>

--- a/src/test/java/com/example/MnM/boundedContext/chat/controller/RoomControllerTest.java
+++ b/src/test/java/com/example/MnM/boundedContext/chat/controller/RoomControllerTest.java
@@ -1,9 +1,10 @@
 package com.example.MnM.boundedContext.chat.controller;
 
-import com.example.MnM.boundedContext.chat.entity.ChatRoom;
-import com.example.MnM.boundedContext.chat.repository.RoomRepository;
+import com.example.MnM.boundedContext.room.entity.ChatRoom;
+import com.example.MnM.boundedContext.room.repository.RoomRepository;
 import com.example.MnM.boundedContext.member.entity.Member;
 import com.example.MnM.boundedContext.member.repository.MemberRepository;
+import com.example.MnM.boundedContext.room.controller.RoomController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/example/MnM/boundedContext/chat/controller/RoomControllerTest.java
+++ b/src/test/java/com/example/MnM/boundedContext/chat/controller/RoomControllerTest.java
@@ -83,33 +83,5 @@ class RoomControllerTest {
                 .andExpect(status().is2xxSuccessful());
     }
 
-    @DisplayName("채팅 방 삭제 성공")
-    @WithUserDetails("user3")
-    @Test
-    void deleteRoom() throws Exception {
-        Member user3 = memberRepository.findByUsername("user3").orElseThrow();
-        String roomId = "uuid";
-
-        String username = user3.getUsername();
-        Long userId = user3.getId();
-        ChatRoom room = ChatRoom.builder()
-                .secretId(roomId)
-                .createUser(username)
-                .createUserId(userId)
-                .build();
-        roomRepository.save(room);
-
-        mvc.perform(delete("/chat/room/delete")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .param("roomId", roomId)
-                        .param("username", username)
-                        .param("userId", String.valueOf(userId))
-                        .with(csrf()))
-                .andExpect(handler().handlerType(RoomController.class))
-                .andExpect(handler().methodName("deleteRoom"))
-                .andExpect(status().is2xxSuccessful());
-    }
-
-
 
 }

--- a/src/test/java/com/example/MnM/boundedContext/chat/infra/InspectSentimentServiceTest.java
+++ b/src/test/java/com/example/MnM/boundedContext/chat/infra/InspectSentimentServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.MnM.boundedContext.chat.infra;
 
+import com.example.MnM.boundedContext.chat.dto.SentimentDto;
 import com.example.MnM.boundedContext.chat.entity.EmotionDegree;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,15 +20,14 @@ class InspectSentimentServiceTest {
 
     @Test
     void inspectTest() throws IOException, ExecutionException, InterruptedException {
-        String tendency ="ISFJ";
+
         String msg = "hello world";
-        CompletableFuture<EmotionDegree> sentiment = inspectSentimentService.chatInspectSentiment(tendency, msg);
+        CompletableFuture<SentimentDto> sentiment = inspectSentimentService.chatInspectSentiment(msg);
 
-        EmotionDegree emotionDegree = sentiment.get();
+        SentimentDto emotionDegree = sentiment.get();
 
-        assertThat(emotionDegree.getMagnitude()).isInstanceOf(Float.class);
-        assertThat(emotionDegree.getScore()).isInstanceOf(Float.class);
-        assertThat(emotionDegree.getTendency()).isEqualTo(tendency);
+        assertThat(emotionDegree.magnitude()).isInstanceOf(Float.class);
+        assertThat(emotionDegree.score()).isInstanceOf(Float.class);
     }
 
 }

--- a/src/test/java/com/example/MnM/boundedContext/chat/service/RoomChatService.java
+++ b/src/test/java/com/example/MnM/boundedContext/chat/service/RoomChatService.java
@@ -22,25 +22,25 @@ public class RoomChatService {
     RoomRepository roomRepository;
 
     @Autowired
-    RoomService roomService;
+    ChatService chatService;
 
     @MockBean
-    ChatService mockService;
+    RoomService roomService;
 
-    @DisplayName("방 삭제시 해당 채팅 로그 영속화")
+
+    @DisplayName("채팅 삭제후 방 삭제")
     @Test
-    void saveChatWhenDeleteRoom() {
+    void deleteCacheChatWillDeleteRoom() {
         ChatRoom room = ChatRoom.builder()
                 .secretId("secretId")
                 .build();
         roomRepository.save(room);
 
-        doNothing().when(mockService).saveChatToCache(any(), any());
-        doNothing().when(mockService).deleteCacheChat(room.getSecretId());
+        doNothing().when(roomService).deleteRoom(room.getSecretId());
 
-        roomService.deleteRoom(room.getSecretId());
+        chatService.deleteCacheChat("secretId");
 
-        verify(mockService,times(1)).saveChatToDb(any(),any());
-        verify(mockService,times(1)).deleteCacheChat(any());
+        verify(roomService,times(1)).deleteRoom(any());
     }
+
 }

--- a/src/test/java/com/example/MnM/boundedContext/chat/service/RoomChatService.java
+++ b/src/test/java/com/example/MnM/boundedContext/chat/service/RoomChatService.java
@@ -1,7 +1,8 @@
 package com.example.MnM.boundedContext.chat.service;
 
-import com.example.MnM.boundedContext.chat.entity.ChatRoom;
-import com.example.MnM.boundedContext.chat.repository.RoomRepository;
+import com.example.MnM.boundedContext.room.entity.ChatRoom;
+import com.example.MnM.boundedContext.room.repository.RoomRepository;
+import com.example.MnM.boundedContext.room.service.RoomService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/example/MnM/boundedContext/chat/service/RoomServiceTest.java
+++ b/src/test/java/com/example/MnM/boundedContext/chat/service/RoomServiceTest.java
@@ -1,8 +1,9 @@
 package com.example.MnM.boundedContext.chat.service;
 
 import com.example.MnM.base.exception.NotFoundRoomException;
-import com.example.MnM.boundedContext.chat.entity.ChatRoom;
-import com.example.MnM.boundedContext.chat.repository.RoomRepository;
+import com.example.MnM.boundedContext.room.entity.ChatRoom;
+import com.example.MnM.boundedContext.room.repository.RoomRepository;
+import com.example.MnM.boundedContext.room.service.RoomService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## PR 생성이유
---
#### 방 삭제 로직을 구현하였고 yml을 jasypt로 암호화 하였습니다.

## 주요 변화사항
---
#### 방 삭제 로직을 구현 및 수정 하였습니다. (현재  방에 1명만 있는 상태로 종료를 하면 에러가 나옵니다 추후 single로 로직을 옮길 예정입니다.)
#### 감정 분석 로직을 수정하였습니다. 기존에 chatService에서 모든 로직을 수행하였는데 퍼사드 클래스를 하나 만들어서 처리하도록 하였습니다. 감정 분석 로직은 비동기로 진행됩니다.
####  yml 암호화를 진행하였습니다. vm 옵션에 키를 넣어야만 진행이 됩니다.

## 이 부분을 중점으로 봐주세요
---
내용
####  현재 문제가 방 삭제 로직의 경우 방 주인이 나가게 되면 바로 방 밖으로 나가지는데 이 때 방 삭제 로직을 비동기로 구현하여서삭제후에도 방이 보이는 버그가 있습니다. 로직을 보시고 고치거나 다른 방안이 있으면 이야기해주시면 감사합니다.
#### 비동기 로직과 메시지 테스트 코드 작성이 어려운 상황입니다. 좋은 방법이 있으면 알려주시면 감사합니다.

close #35 
