### PR TITLE
이메일 전송, 아이디/ 비밀번호 찾

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,10 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	//database
-	implementation 'com.mysql:mysql-connector-j:8.0.33'
+	//implementation 'com.mysql:mysql-connector-j:8.0.33'
+
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	implementation 'com.h2database:h2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/com/example/MnM/base/appConfig/AppConfig.java
+++ b/src/main/java/com/example/MnM/base/appConfig/AppConfig.java
@@ -11,6 +11,7 @@ public class AppConfig {
     private static String siteName;
     @Getter
     private static String siteBaseUrl;
+
     private static String activeProfile;
     @Getter
     private static String key;
@@ -44,6 +45,21 @@ public class AppConfig {
     public static boolean isProd() {
         return activeProfile.equals("prod");
 
+    }
+
+    @Value("${spring.profiles.active}")
+    public void setActiveProfile(String value) {
+        activeProfile = value;
+    }
+
+    @Value("${custom.siteName}")
+    public void setSiteName(String siteName) {
+        AppConfig.siteName = siteName;
+    }
+
+    @Value("${custom.site.baseUrlWithPort}")
+    public void setSiteBaseUrl(String baseUrlWithPort) {
+        AppConfig.siteBaseUrl = baseUrlWithPort;
     }
 
 }

--- a/src/main/java/com/example/MnM/base/appConfig/AppConfig.java
+++ b/src/main/java/com/example/MnM/base/appConfig/AppConfig.java
@@ -4,10 +4,14 @@ import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
-import java.time.LocalDateTime;
 
 @Configuration
 public class AppConfig {
+    @Getter
+    private static String siteName;
+    @Getter
+    private static String siteBaseUrl;
+    private static String activeProfile;
     @Getter
     private static String key;
 
@@ -24,12 +28,22 @@ public class AppConfig {
         AppConfig.tokenValiditySeconds = tokenValiditySeconds;
     }
 
+
     @Getter
     private static String chatUrl;
 
     @Value("${custom.site.baseUrl}")
     public void setChatUrl(String chatUrl) {
         AppConfig.chatUrl = chatUrl;
+    }
+
+    public static boolean isNotProd() {
+        return !isProd();
+    }
+
+    public static boolean isProd() {
+        return activeProfile.equals("prod");
+
     }
 
 }

--- a/src/main/java/com/example/MnM/base/security/SecurityConfig.java
+++ b/src/main/java/com/example/MnM/base/security/SecurityConfig.java
@@ -45,12 +45,9 @@ public class SecurityConfig {
                                 .loginPage("/member/login")
                 )
                 .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
-                       .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
-                                .hasAuthority("ADMIN")
-                        .requestMatchers("/mbtiTest", "member/me", "member/editMyPage", "member/delete", "member/editProfile")
-                                .hasAuthority("USER")
-                                .anyRequest()
-                                .permitAll()
+                       .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").hasAuthority("ADMIN")
+                        .requestMatchers("/mbtiTest", "member/me", "member/editMyPage", "member/delete", "member/editProfile", "member/emailVerification").hasAuthority("USER").anyRequest().permitAll()
+
                 )//추후 관리자 페이지나 api문서 화면, 등등 설정함
                 .rememberMe(rememberMe -> rememberMe //쿠키 적용, 아이디 기억하기 기능
                         .rememberMeParameter("remember")

--- a/src/main/java/com/example/MnM/base/security/SecurityConfig.java
+++ b/src/main/java/com/example/MnM/base/security/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").hasAuthority("ADMIN")
-                        .requestMatchers("/mbtiTest", "member/me", "member/editMyPage", "member/delete", "member/editProfile", "member/emailVerification").hasAuthority("USER").anyRequest().permitAll()
+                        .requestMatchers("/mbtiTest", "member/me", "member/editMyPage", "member/delete", "member/editProfile", "member/emailVerification", "member/modifyPassword")
+                        .hasAuthority("USER").anyRequest().permitAll()
 
                 )//추후 관리자 페이지나 api문서 화면, 등등 설정함
                 .rememberMe(rememberMe -> rememberMe //쿠키 적용, 아이디 기억하기 기능

--- a/src/main/java/com/example/MnM/boundedContext/email/entity/SendEmailLog.java
+++ b/src/main/java/com/example/MnM/boundedContext/email/entity/SendEmailLog.java
@@ -1,6 +1,7 @@
 package com.example.MnM.boundedContext.email.entity;
 
-import com.ll.exam.final__2022_10_08.app.base.entity.BaseEntity;
+
+import com.example.MnM.base.baseEntity.BaseEntity;
 import jakarta.persistence.Entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/MnM/boundedContext/email/entity/SendEmailLog.java
+++ b/src/main/java/com/example/MnM/boundedContext/email/entity/SendEmailLog.java
@@ -1,0 +1,27 @@
+package com.example.MnM.boundedContext.email.entity;
+
+import com.ll.exam.final__2022_10_08.app.base.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Setter
+@Getter
+@NoArgsConstructor
+@SuperBuilder
+@ToString(callSuper = true)
+public class SendEmailLog extends BaseEntity {
+    private String resultCode;
+    private String message;
+    private String email;
+    private String subject;
+    private String body;
+    private LocalDateTime sendEndDate;
+    private LocalDateTime failDate;
+}

--- a/src/main/java/com/example/MnM/boundedContext/email/entity/SendEmailLog.java
+++ b/src/main/java/com/example/MnM/boundedContext/email/entity/SendEmailLog.java
@@ -12,17 +12,28 @@ import lombok.experimental.SuperBuilder;
 import java.time.LocalDateTime;
 
 @Entity
-@Setter
 @Getter
 @NoArgsConstructor
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 @ToString(callSuper = true)
 public class SendEmailLog extends BaseEntity {
-    private String resultCode;
-    private String message;
+    private String resultCode; //
+    private String message; //
     private String email;
     private String subject;
     private String body;
-    private LocalDateTime sendEndDate;
-    private LocalDateTime failDate;
+    private LocalDateTime sendEndDate; //
+    private LocalDateTime failDate; //
+
+    public void setSuccessSendEmailLog(String resultCode, String message, LocalDateTime dateTime){
+        this.resultCode = resultCode;
+        this.message = message;
+        this.sendEndDate  = dateTime;
+    }
+
+    public void setFailSendEmailLog(String resultCode, String message, LocalDateTime dateTime){
+        this.resultCode = resultCode;
+        this.message = message;
+        this.failDate  = dateTime;
+    }
 }

--- a/src/main/java/com/example/MnM/boundedContext/email/repository/SendEmailLogRepository.java
+++ b/src/main/java/com/example/MnM/boundedContext/email/repository/SendEmailLogRepository.java
@@ -1,6 +1,7 @@
 package com.example.MnM.boundedContext.email.repository;
 
-import com.ll.exam.final__2022_10_08.app.email.entity.SendEmailLog;
+
+import com.example.MnM.boundedContext.email.entity.SendEmailLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SendEmailLogRepository extends JpaRepository<SendEmailLog, Long> {

--- a/src/main/java/com/example/MnM/boundedContext/email/repository/SendEmailLogRepository.java
+++ b/src/main/java/com/example/MnM/boundedContext/email/repository/SendEmailLogRepository.java
@@ -1,0 +1,7 @@
+package com.example.MnM.boundedContext.email.repository;
+
+import com.ll.exam.final__2022_10_08.app.email.entity.SendEmailLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SendEmailLogRepository extends JpaRepository<SendEmailLog, Long> {
+}

--- a/src/main/java/com/example/MnM/boundedContext/email/service/EmailService.java
+++ b/src/main/java/com/example/MnM/boundedContext/email/service/EmailService.java
@@ -51,14 +51,12 @@ public class EmailService {
 
     @Transactional
     public void setCompleted(SendEmailLog sendEmailLog, String resultCode, String message) {
-        if (resultCode.startsWith("S-")) {
-            sendEmailLog.setSendEndDate(LocalDateTime.now());
-        } else {
-            sendEmailLog.setFailDate(LocalDateTime.now());
-        }
 
-        sendEmailLog.setResultCode(resultCode);
-        sendEmailLog.setMessage(message);
+        if (resultCode.startsWith("S-")) {
+            sendEmailLog.setSuccessSendEmailLog(resultCode, message, LocalDateTime.now());
+        } else {
+            sendEmailLog.setFailSendEmailLog(resultCode, message, LocalDateTime.now());
+        }
 
         emailLogRepository.save(sendEmailLog);
     }

--- a/src/main/java/com/example/MnM/boundedContext/email/service/EmailService.java
+++ b/src/main/java/com/example/MnM/boundedContext/email/service/EmailService.java
@@ -39,9 +39,6 @@ public class EmailService {
     }
 
     private RsData trySend(String email, String title, String body) {
-        /*if (*//*AppConfig.isNotProd() && *//*!email.equals("skrlfxo97@gmail.com")) {
-            return RsData.of("S-0", "메일이 발송되었습니다.");
-        }*/
 
         try {
             emailSenderService.send(email, "no-reply@no-reply.com", title, body);

--- a/src/main/java/com/example/MnM/boundedContext/email/service/EmailService.java
+++ b/src/main/java/com/example/MnM/boundedContext/email/service/EmailService.java
@@ -1,0 +1,67 @@
+package com.example.MnM.boundedContext.email.service;
+
+import com.ll.exam.final__2022_10_08.app.AppConfig;
+import com.ll.exam.final__2022_10_08.app.base.dto.RsData;
+import com.ll.exam.final__2022_10_08.app.email.entity.SendEmailLog;
+import com.ll.exam.final__2022_10_08.app.email.repository.SendEmailLogRepository;
+import com.ll.exam.final__2022_10_08.app.emailSender.service.EmailSenderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.MailException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmailService {
+    private final SendEmailLogRepository emailLogRepository;
+    private final EmailSenderService emailSenderService;
+
+    @Transactional
+    public RsData sendEmail(String email, String subject, String body) {
+        SendEmailLog sendEmailLog = SendEmailLog
+                .builder()
+                .email(email)
+                .subject(subject)
+                .body(body)
+                .build();
+
+        emailLogRepository.save(sendEmailLog);
+
+        RsData trySendRs = trySend(email, subject, body);
+
+        setCompleted(sendEmailLog, trySendRs.getResultCode(), trySendRs.getMsg());
+
+        return RsData.of("S-1", "메일이 발송되었습니다.", sendEmailLog.getId());
+    }
+
+    private RsData trySend(String email, String title, String body) {
+        if (AppConfig.isNotProd() && email.equals("jangka2048@gmail.com") == false) {
+            return RsData.of("S-0", "메일이 발송되었습니다.");
+        }
+
+        try {
+            emailSenderService.send(email, "no-reply@no-reply.com", title, body);
+
+            return RsData.of("S-1", "메일이 발송되었습니다.");
+        } catch (MailException e) {
+            return RsData.of("F-1", e.getMessage());
+        }
+    }
+
+    @Transactional
+    public void setCompleted(SendEmailLog sendEmailLog, String resultCode, String message) {
+        if (resultCode.startsWith("S-")) {
+            sendEmailLog.setSendEndDate(LocalDateTime.now());
+        } else {
+            sendEmailLog.setFailDate(LocalDateTime.now());
+        }
+
+        sendEmailLog.setResultCode(resultCode);
+        sendEmailLog.setMessage(message);
+
+        emailLogRepository.save(sendEmailLog);
+    }
+}

--- a/src/main/java/com/example/MnM/boundedContext/email/service/EmailService.java
+++ b/src/main/java/com/example/MnM/boundedContext/email/service/EmailService.java
@@ -39,9 +39,9 @@ public class EmailService {
     }
 
     private RsData trySend(String email, String title, String body) {
-        if (AppConfig.isNotProd() && !email.equals("jangka2048@gmail.com")) {
+        /*if (*//*AppConfig.isNotProd() && *//*!email.equals("skrlfxo97@gmail.com")) {
             return RsData.of("S-0", "메일이 발송되었습니다.");
-        }
+        }*/
 
         try {
             emailSenderService.send(email, "no-reply@no-reply.com", title, body);

--- a/src/main/java/com/example/MnM/boundedContext/email/service/EmailService.java
+++ b/src/main/java/com/example/MnM/boundedContext/email/service/EmailService.java
@@ -1,10 +1,11 @@
 package com.example.MnM.boundedContext.email.service;
 
-import com.ll.exam.final__2022_10_08.app.AppConfig;
-import com.ll.exam.final__2022_10_08.app.base.dto.RsData;
-import com.ll.exam.final__2022_10_08.app.email.entity.SendEmailLog;
-import com.ll.exam.final__2022_10_08.app.email.repository.SendEmailLogRepository;
-import com.ll.exam.final__2022_10_08.app.emailSender.service.EmailSenderService;
+
+import com.example.MnM.base.appConfig.AppConfig;
+import com.example.MnM.base.rsData.RsData;
+import com.example.MnM.boundedContext.email.entity.SendEmailLog;
+import com.example.MnM.boundedContext.email.repository.SendEmailLogRepository;
+import com.example.MnM.boundedContext.emailSender.service.EmailSenderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailException;
 import org.springframework.stereotype.Service;
@@ -38,7 +39,7 @@ public class EmailService {
     }
 
     private RsData trySend(String email, String title, String body) {
-        if (AppConfig.isNotProd() && email.equals("jangka2048@gmail.com") == false) {
+        if (AppConfig.isNotProd() && !email.equals("jangka2048@gmail.com")) {
             return RsData.of("S-0", "메일이 발송되었습니다.");
         }
 

--- a/src/main/java/com/example/MnM/boundedContext/emailSender/service/EmailSenderService.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailSender/service/EmailSenderService.java
@@ -1,0 +1,28 @@
+package com.example.MnM.boundedContext.emailSender.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+
+public interface EmailSenderService {
+    void send(String to, String from, String title, String body);
+}
+
+
+@Service
+@RequiredArgsConstructor
+class GmailEmailSenderService implements EmailSenderService {
+    private final JavaMailSender mailSender;
+
+    @Override
+    public void send(String to, String from, String title, String body) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setFrom(from);
+        message.setSubject(title);
+        message.setText(body);
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/example/MnM/boundedContext/emailSender/service/EmailSenderService.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailSender/service/EmailSenderService.java
@@ -1,5 +1,9 @@
 package com.example.MnM.boundedContext.emailSender.service;
 
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -18,11 +22,16 @@ class GmailEmailSenderService implements EmailSenderService {
 
     @Override
     public void send(String to, String from, String title, String body) {
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(to);
-        message.setFrom(from);
-        message.setSubject(title);
-        message.setText(body);
+        MimeMessage message = mailSender.createMimeMessage();
+        try {
+            message.setRecipient(Message.RecipientType.TO, new InternetAddress(to));
+            message.setFrom(new InternetAddress(from));
+            message.setSubject(title);
+            message.setContent(body, "text/html;charset=UTF-8");
+        } catch (MessagingException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
         mailSender.send(message);
     }
 }

--- a/src/main/java/com/example/MnM/boundedContext/emailVerification/Entity/EmailVerification.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailVerification/Entity/EmailVerification.java
@@ -6,14 +6,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Setter
 @Getter
 @NoArgsConstructor
 @ToString

--- a/src/main/java/com/example/MnM/boundedContext/emailVerification/Entity/EmailVerification.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailVerification/Entity/EmailVerification.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@RequiredArgsConstructor
 @ToString
 @SuperBuilder
 public class EmailVerification {

--- a/src/main/java/com/example/MnM/boundedContext/emailVerification/Entity/EmailVerification.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailVerification/Entity/EmailVerification.java
@@ -1,0 +1,28 @@
+package com.example.MnM.boundedContext.emailVerification.Entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Setter
+@Getter
+@NoArgsConstructor
+@ToString
+@SuperBuilder
+public class EmailVerification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private long memberId;
+    private String code;
+    private LocalDateTime expireDate;
+}

--- a/src/main/java/com/example/MnM/boundedContext/emailVerification/controller/EmailVerificationController.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailVerification/controller/EmailVerificationController.java
@@ -1,0 +1,35 @@
+package com.example.MnM.boundedContext.emailVerification.controller;
+
+
+import com.example.MnM.base.rq.Rq;
+import com.example.MnM.base.rsData.RsData;
+import com.example.MnM.boundedContext.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/emailVerification")
+public class EmailVerificationController {
+    private final MemberService memberService;
+    private final Rq rq;
+
+    @GetMapping("/verify")
+    public String verify(long memberId, String code) {
+        RsData verifyEmailRsData = memberService.verifyEmail(memberId, code);
+
+        if (verifyEmailRsData.isFail()) {
+            return rq.redirectWithMsg("/", verifyEmailRsData);
+        }
+
+        String successMsg = verifyEmailRsData.getMsg();
+
+        if (rq.isLogout()) {
+            return rq.redirectWithMsg("/member/login", successMsg);
+        }
+
+        return rq.redirectWithMsg("/", successMsg);
+    }
+}

--- a/src/main/java/com/example/MnM/boundedContext/emailVerification/controller/EmailVerificationController.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailVerification/controller/EmailVerificationController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequiredArgsConstructor

--- a/src/main/java/com/example/MnM/boundedContext/emailVerification/controller/EmailVerificationController.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailVerification/controller/EmailVerificationController.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
 
 @Controller
 @RequiredArgsConstructor

--- a/src/main/java/com/example/MnM/boundedContext/emailVerification/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailVerification/repository/EmailVerificationRepository.java
@@ -1,0 +1,11 @@
+package com.example.MnM.boundedContext.emailVerification.repository;
+
+
+import com.example.MnM.boundedContext.emailVerification.Entity.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+    public Optional<EmailVerification> findByMemberId(long memberId);
+}

--- a/src/main/java/com/example/MnM/boundedContext/emailVerification/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailVerification/repository/EmailVerificationRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
-    public Optional<EmailVerification> findByMemberId(long memberId);
+    Optional<EmailVerification> findByMemberId(long memberId);
 }

--- a/src/main/java/com/example/MnM/boundedContext/emailVerification/service/EmailVerificationService.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailVerification/service/EmailVerificationService.java
@@ -1,0 +1,64 @@
+package com.example.MnM.boundedContext.emailVerification.service;
+
+
+import com.example.MnM.base.appConfig.AppConfig;
+import com.example.MnM.base.rsData.RsData;
+import com.example.MnM.boundedContext.email.service.EmailService;
+import com.example.MnM.boundedContext.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.AsyncResult;
+import org.springframework.stereotype.Service;
+import org.springframework.util.concurrent.ListenableFuture;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+    private final EmailService emailService;
+    private final AttrService attrService;
+
+    @Async
+    public ListenableFuture<RsData<Long>> send(Member member) {
+        String email = member.getEmail();
+        String title = "[%s 이메일인증] 안녕하세요 %s님. 링크를 클릭하여 회원가입을 완료해주세요.".formatted(AppConfig.getSiteName(), member.getName());
+        String url = genEmailVerificationUrl(member);
+
+        RsData<Long> sendEmailRs = emailService.sendEmail(email, title, url);
+
+        return new AsyncResult<>(sendEmailRs);
+    }
+
+    public String genEmailVerificationUrl(Member member) {
+        return genEmailVerificationUrl(member.getId());
+    }
+
+    public String genEmailVerificationUrl(long memberId) {
+        String code = genEmailVerificationCode(memberId);
+
+        return AppConfig.getSiteBaseUrl() + "/emailVerification/verify?memberId=%d&code=%s".formatted(memberId, code);
+    }
+
+    public String genEmailVerificationCode(long memberId) {
+        String code = UUID.randomUUID().toString();
+        //attrService.set("member__%d__extra__emailVerificationCode".formatted(memberId), code, LocalDateTime.now().plusSeconds(60 * 60 * 1));
+
+        return code;
+    }
+
+    public RsData verifyVerificationCode(long memberId, String code) {
+        //String foundCode = attrService.get("member__%d__extra__emailVerificationCode".formatted(memberId), "");
+
+        if (foundCode.equals(code) == false) {
+            return RsData.of("F-1", "만료되었거나 유효하지 않은 코드입니다.");
+        }
+
+        return RsData.of("S-1", "인증된 코드 입니다.");
+    }
+
+    public String findEmailVerificationCode(long memberId) {
+        return attrService.get("member__%d__extra__emailVerificationCode".formatted(memberId), "");
+    }
+}

--- a/src/main/java/com/example/MnM/boundedContext/emailVerification/service/EmailVerificationService.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailVerification/service/EmailVerificationService.java
@@ -100,4 +100,6 @@ public class EmailVerificationService {
         LocalDateTime expireDate = emailVerification.getExpireDate();
         return expireDate.isBefore(LocalDateTime.now());
     }
+
+
 }

--- a/src/main/java/com/example/MnM/boundedContext/emailVerification/service/EmailVerificationService.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailVerification/service/EmailVerificationService.java
@@ -69,7 +69,7 @@ public class EmailVerificationService {
         EmailVerification emailVerification = EmailVerification.builder()
                 .memberId(memberId)
                 .code(code)
-                .expireDate(LocalDateTime.now().plusSeconds(60 * 60 * 1))
+                .expireDate(LocalDateTime.now().plusSeconds(60 * 60))
                 .build();
 
         emailVerificationRepository.save(emailVerification);

--- a/src/main/java/com/example/MnM/boundedContext/emailVerification/service/EmailVerificationService.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailVerification/service/EmailVerificationService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.concurrent.ListenableFuture;
 
 
@@ -25,6 +27,7 @@ public class EmailVerificationService {
     private final EmailService emailService;
     private final EmailVerificationRepository emailVerificationRepository;
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Async
     public CompletableFuture<RsData<Long>> send(Member member, String email) {
         if (email == null) {

--- a/src/main/java/com/example/MnM/boundedContext/emailVerification/service/EmailVerificationService.java
+++ b/src/main/java/com/example/MnM/boundedContext/emailVerification/service/EmailVerificationService.java
@@ -4,6 +4,8 @@ package com.example.MnM.boundedContext.emailVerification.service;
 import com.example.MnM.base.appConfig.AppConfig;
 import com.example.MnM.base.rsData.RsData;
 import com.example.MnM.boundedContext.email.service.EmailService;
+import com.example.MnM.boundedContext.emailVerification.Entity.EmailVerification;
+import com.example.MnM.boundedContext.emailVerification.repository.EmailVerificationRepository;
 import com.example.MnM.boundedContext.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
@@ -12,46 +14,70 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.concurrent.ListenableFuture;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class EmailVerificationService {
     private final EmailService emailService;
-    private final AttrService attrService;
+    private final EmailVerificationRepository emailVerificationRepository;
 
     @Async
-    public ListenableFuture<RsData<Long>> send(Member member) {
-        String email = member.getEmail();
-        String title = "[%s 이메일인증] 안녕하세요 %s님. 링크를 클릭하여 회원가입을 완료해주세요.".formatted(AppConfig.getSiteName(), member.getName());
-        String url = genEmailVerificationUrl(member);
+    public void send(Member member, String email) {
+        if (email == null) {
+            email = member.getEmail();
+        }
+        //TODO: 하드 코딩 제거하기
+        String title = "[하루10분 이메일인증] 안녕하세요 %s님. 링크를 클릭하여 이메일 인증을 완료해주세요.".formatted(member.getUsername());
+        String url = "<a href=\""+ genEmailVerificationUrl(member) + "\">이메일 인증 링크</a>";
 
-        RsData<Long> sendEmailRs = emailService.sendEmail(email, title, url);
-
-        return new AsyncResult<>(sendEmailRs);
+        emailService.sendEmail(email, title, url);
     }
 
     public String genEmailVerificationUrl(Member member) {
         return genEmailVerificationUrl(member.getId());
     }
 
+    /*
+        이메일 인증 URI를 생성하는 메소드.
+        member 테이블의 id 컬럼 데이터를 이용하여, 해당 member가 이전에 발급 받은 인증 코드가 있는지 판단하고,
+        기존 인증 코드가 존재하지 않는다면, 새로운 인증 코드를 발급하여 인증 메일을 보내게 됩니다.
+        기존 인증 코드가 존재한다면, 유효 기간을 검증하고,
+        유효 기간이 지난 코드의 경우 파기(DB에서 삭제) 후, 인증 코드를 재발급 하여 인증 메일을 발송합니다.
+        유효 기간이 지나지 않은 경우, 인증 코드를 새로 발급하지 않고, 인증 메일을 보낼 때 사용합니다.
+    */
     public String genEmailVerificationUrl(long memberId) {
-        String code = genEmailVerificationCode(memberId);
+        Optional<EmailVerification> emailVerification = this.findEmailVerification(memberId);
+        String code = emailVerification.map(EmailVerification::getCode).orElseGet(() -> genEmailVerificationCode(memberId));
 
-        return AppConfig.getSiteBaseUrl() + "/emailVerification/verify?memberId=%d&code=%s".formatted(memberId, code);
+        if (emailVerification.isPresent() && isVerificationExpired(emailVerification.get())) {
+            emailVerificationRepository.delete(emailVerification.get());
+            code = genEmailVerificationCode(memberId);
+        }
+
+        //TODO: 하드 코딩 제거하기
+        return "http://localhost:8080/emailVerification/verify?memberId=%d&code=%s".formatted(memberId, code);
     }
 
     public String genEmailVerificationCode(long memberId) {
         String code = UUID.randomUUID().toString();
-        //attrService.set("member__%d__extra__emailVerificationCode".formatted(memberId), code, LocalDateTime.now().plusSeconds(60 * 60 * 1));
+
+        EmailVerification emailVerification = EmailVerification.builder()
+                .memberId(memberId)
+                .code(code)
+                .expireDate(LocalDateTime.now().plusSeconds(60 * 60 * 1))
+                .build();
+
+        emailVerificationRepository.save(emailVerification);
 
         return code;
     }
 
     public RsData verifyVerificationCode(long memberId, String code) {
-        //String foundCode = attrService.get("member__%d__extra__emailVerificationCode".formatted(memberId), "");
+        String foundedCode = findEmailVerificationCode(memberId);
 
-        if (foundCode.equals(code) == false) {
+        if (!foundedCode.equals(code)) {
             return RsData.of("F-1", "만료되었거나 유효하지 않은 코드입니다.");
         }
 
@@ -59,6 +85,16 @@ public class EmailVerificationService {
     }
 
     public String findEmailVerificationCode(long memberId) {
-        return attrService.get("member__%d__extra__emailVerificationCode".formatted(memberId), "");
+        Optional<EmailVerification> emailVerification = findEmailVerification(memberId);
+        return emailVerification.map(EmailVerification::getCode).orElse(null);
+    }
+
+    public Optional<EmailVerification> findEmailVerification(long memberId) {
+        return emailVerificationRepository.findByMemberId(memberId);
+    }
+
+    boolean isVerificationExpired(EmailVerification emailVerification) {
+        LocalDateTime expireDate = emailVerification.getExpireDate();
+        return expireDate.isBefore(LocalDateTime.now());
     }
 }

--- a/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
@@ -47,12 +47,26 @@ public class MemberController {
     @PostMapping("/join")
     public String join(@Valid MemberDto memberDto, BindingResult bindingResult) {
         if(bindingResult.hasErrors()){
-            System.out.println(memberDto.getUsername() + "222222222" + memberDto.getEmail() + "22222222222222222" + memberDto.getNickname());
+            String username = memberDto.getUsername();
+            String password = memberDto.getPassword();
+            String name = memberDto.getName();
+            String email = memberDto.getEmail();
+            String nickname = memberDto.getNickname();
+            Integer height = memberDto.getHeight();
+            Integer age = memberDto.getAge();
+            String locate =memberDto.getLocate();
+            String gender = memberDto.getGender();
+            String mbti = memberDto.getMbti();
+            String hobby = memberDto.getHobby();
+            String introduce = memberDto.getIntroduce();
+
+            System.out.println(username + "22" + password + "22" + name + "22" + email + "22" + nickname + "22" + height + "22" + age + "22" + locate + "22" +gender + "22" + mbti + "22" + hobby + "22" + introduce);
+
             return rq.redirectWithMsg("/member/join", "회원가입 실패, 입력하신 정보를 다시 확인해주세요.");
         }
         RsData<Member> joinRs = memberService.join(memberDto);
         if (joinRs.isFail()) {
-            return rq.historyBack(joinRs);
+            return rq.redirectWithMsg("member/join",joinRs);
         }
 
         return rq.redirectWithMsg("/member/login", joinRs.getMsg());

--- a/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
@@ -135,7 +135,7 @@ public class MemberController {
     @PreAuthorize("isAnonymous()")
     @GetMapping("/findUserId")
     public String showFindUserId() {
-        return "/member/findUserId";
+        return "/member/findUsername";
     }
 
     @PreAuthorize("isAnonymous()")
@@ -181,7 +181,7 @@ public class MemberController {
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/modifyPassword")
     public String showModifyPassword() {
-        return "usr/member/modifyPassword";
+        return "member/modifyPassword";
     }
 
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
@@ -178,20 +178,21 @@ public class MemberController {
         return rq.redirectWithMsg("/member/login", sendTempLoginPwToEmailResultData);
     }
 
-    @PreAuthorize("isAuthenticated()")
+
     @GetMapping("/modifyPassword")
     public String showModifyPassword() {
         return "member/modifyPassword";
     }
 
-    @PreAuthorize("isAuthenticated()")
+
     @PostMapping("/modifyPassword")
     public String modifyPassword(String oldPassword, String password, RedirectAttributes redirectAttributes) {
-        Member actor = rq.getMember();
-        RsData modifyRsData = memberService.modifyPassword(actor, password, oldPassword);
+        Member member = rq.getMember();
+        RsData modifyRsData = memberService.modifyPassword(member, password, oldPassword);
         redirectAttributes.addFlashAttribute("message", modifyRsData.getMsg());
+
         if (modifyRsData.isFail()) {
-            return rq.redirectWithMsg("/usr/member/modifyPassword", modifyRsData);
+            return rq.redirectWithMsg("/member/modifyPassword", modifyRsData);
         }
         return rq.redirectWithMsg("/", modifyRsData);
     }

--- a/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
@@ -141,16 +141,16 @@ public class MemberController {
     @PreAuthorize("isAnonymous()")
     @PostMapping("/findUserId")
     public String findUserId(String email) {
-        Member actor = memberService.findByEmail(email).orElse(null);
+        Member member = memberService.findByEmail(email).orElse(null);
 
-        if (actor == null) {
+        if (member == null) {
             return rq.historyBack(RsData.of("F-1", "해당 이메일로 가입된 계정이 존재하지 않습니다."));
         }
 
-        String foundedUserId = actor.getUsername();
-        String successMsg = "해당 이메일로 가입한 계정의 아이디는 '%s' 입니다.".formatted(foundedUserId);
+        String foundedUsername = member.getUsername();
+        String successMsg = "해당 이메일로 가입한 계정의 아이디는 '%s' 입니다.".formatted(foundedUsername);
 
-        return rq.redirectWithMsg("/usr/member/login?userId=%s".formatted(foundedUserId), RsData.of("S-1", successMsg));
+        return rq.redirectWithMsg("/usr/member/login?userId=%s".formatted(foundedUsername), RsData.of("S-1", successMsg));
     }
 
     @PreAuthorize("isAnonymous()")

--- a/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
@@ -47,7 +47,7 @@ public class MemberController {
     @PostMapping("/join")
     public String join(@Valid MemberDto memberDto, BindingResult bindingResult) {
         if(bindingResult.hasErrors()){
-            System.out.println(memberDto.getUsername() + "222222222" + memberDto.getEmail() + "22222222222222222");
+            System.out.println(memberDto.getUsername() + "222222222" + memberDto.getEmail() + "22222222222222222" + memberDto.getNickname());
             return rq.redirectWithMsg("/member/join", "회원가입 실패, 입력하신 정보를 다시 확인해주세요.");
         }
         RsData<Member> joinRs = memberService.join(memberDto);

--- a/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/controller/MemberController.java
@@ -43,9 +43,11 @@ public class MemberController {
         return "member/join";
     }
 
+
     @PostMapping("/join")
     public String join(@Valid MemberDto memberDto, BindingResult bindingResult) {
         if(bindingResult.hasErrors()){
+            System.out.println(memberDto.getUsername() + "222222222" + memberDto.getEmail() + "22222222222222222");
             return rq.redirectWithMsg("/member/join", "회원가입 실패, 입력하신 정보를 다시 확인해주세요.");
         }
         RsData<Member> joinRs = memberService.join(memberDto);

--- a/src/main/java/com/example/MnM/boundedContext/member/dto/MemberDto.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/dto/MemberDto.java
@@ -1,7 +1,6 @@
 package com.example.MnM.boundedContext.member.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import lombok.*;
@@ -17,7 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberDto {
 
     @NotBlank
-    @Pattern(regexp = "^(?!.*admin).*$", message = "단어 'admin'을 사용할 수 없습니다.")
+    @Pattern(regexp = "^(?!.*admin)[A-Za-z0-9]+$", message = "영문자와 숫자로만 이루어져야 하며, 단어 'admin'을 사용할 수 없습니다.")
     private String username;
     @NotBlank
     private String password;
@@ -32,7 +31,7 @@ public class MemberDto {
     @Positive
     private Integer height; //키
     @Positive
-    private Integer age; //나이;
+    private Integer age;
 
     private String locate; //지역
 

--- a/src/main/java/com/example/MnM/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/entity/Member.java
@@ -19,7 +19,6 @@ import org.hibernate.annotations.LazyCollectionOption;
 import org.hibernate.annotations.SQLDelete;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.web.multipart.MultipartFile;
 
 
 import java.util.ArrayList;
@@ -64,6 +63,10 @@ public class Member extends BaseEntity {
         this.password =password;
         this.providerType = providerType;
 
+    }
+
+    public void setMemberEmailVerified(Boolean emailVerified){
+        this.emailVerified = emailVerified;
     }
 
     public List<? extends GrantedAuthority> getGrantedAuthorities() { //시큐리티에 등록된 권한

--- a/src/main/java/com/example/MnM/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/entity/Member.java
@@ -105,4 +105,6 @@ public class Member extends BaseEntity {
     public void changeUsername(String name) {
         this.name = name;
     }
+
+    public void changePassword(String password){this.password = password;}
 }

--- a/src/main/java/com/example/MnM/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/entity/Member.java
@@ -42,7 +42,6 @@ public class Member extends BaseEntity {
     private String providerType; //소셜로그인을 위한 제공자 타입
 
 
-
     private boolean deleted = Boolean.FALSE; //soft delete
     //Todo : dateTime으로 교체 ->sql문 수정해야함
 

--- a/src/main/java/com/example/MnM/boundedContext/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/repository/MemberRepository.java
@@ -22,8 +22,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByName(String name); //
 
-    Optional<Member> findByUsernameAndEmail(String username, String email);
-
     List<Member> findByMbti(String mbti);
 
 
@@ -34,5 +32,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @OnDelete(action = OnDeleteAction.CASCADE)
     @Query(value = "DELETE FROM member WHERE id = ?1", nativeQuery = true)
     void deleteHardById(Long id);
+
+    Optional<Member> findByUsernameAndEmail(String userId, String email);
+
+    Optional<Member> findByEmail(String email);
 
 }

--- a/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.example.MnM.boundedContext.member.service;
 import com.example.MnM.base.objectStorage.service.AmazonService;
 import com.example.MnM.base.objectStorage.service.S3FolderName;
 import com.example.MnM.base.rsData.RsData;
+import com.example.MnM.boundedContext.emailVerification.service.EmailVerificationService;
 import com.example.MnM.boundedContext.member.dto.MemberDto;
 import com.example.MnM.boundedContext.member.dto.MemberProfileDto;
 import com.example.MnM.boundedContext.member.entity.Member;
@@ -35,6 +36,8 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
 
     private final AmazonService amazonService;
+
+    private final EmailVerificationService emailVerificationService;
 
     private final MbtiService mbtiService;
 
@@ -200,5 +203,19 @@ public class MemberService {
                 .build();
 
         return RsData.of("S-1", "프로필 사진 교체 완료", memberRepository.save(modifiedProfileMember));
+    }
+
+    @Transactional
+    public RsData verifyEmail(long id, String verificationCode) {
+        RsData verifyVerificationCodeRs = emailVerificationService.verifyVerificationCode(id, verificationCode);
+
+        if (!verifyVerificationCodeRs.isSuccess()) {
+            return verifyVerificationCodeRs;
+        }
+
+        Member member = memberRepository.findById(id).get();
+        member.setEmailVerified(true);
+
+        return RsData.of("S-1", "이메일인증이 완료되었습니다.");
     }
 }

--- a/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
@@ -251,7 +251,7 @@ public class MemberService {
 
     @Transactional
     public RsData sendTempPasswordToEmail(Member actor) {
-        String title = "[하루10분] 임시 패스워드 발송";
+        String title = "[MnM] 임시 패스워드 발송";
         String tempPassword = Ut.getTempPassword(6);
 
         String body = """
@@ -280,7 +280,7 @@ public class MemberService {
     //회원 수정, 삭제
     @Transactional
     public RsData<Member> setTempPassword(Member member, String tempPassword) {
-        Member modifiedMember = member.toBuilder().password(tempPassword).build();
+        Member modifiedMember = member.toBuilder().password(passwordEncoder.encode(tempPassword)).build();
         memberRepository.save(modifiedMember);
 
         return RsData.of("S-1", "회원정보를 수정하였습니다");
@@ -292,7 +292,7 @@ public class MemberService {
             return RsData.of("F-1", "기존 비밀번호가 일치하지 않습니다.");
         }
 
-        Member modifiedMember = member.toBuilder().password(password).build();
+        Member modifiedMember = member.toBuilder().password(passwordEncoder.encode(password)).build();
         memberRepository.save(modifiedMember);
 
         return RsData.of("S-1", "비밀번호가 변경되었습니다.");

--- a/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
@@ -280,8 +280,7 @@ public class MemberService {
     //회원 수정, 삭제
     @Transactional
     public RsData<Member> setTempPassword(Member member, String tempPassword) {
-        Member modifiedMember = member.toBuilder().password(passwordEncoder.encode(tempPassword)).build();
-        memberRepository.save(modifiedMember);
+        member.changePassword(passwordEncoder.encode(tempPassword));
 
         return RsData.of("S-1", "회원정보를 수정하였습니다");
     }
@@ -291,9 +290,7 @@ public class MemberService {
         if (!passwordEncoder.matches(oldPassword, member.getPassword())) {
             return RsData.of("F-1", "기존 비밀번호가 일치하지 않습니다.");
         }
-
-        Member modifiedMember = member.toBuilder().password(passwordEncoder.encode(password)).build();
-        memberRepository.save(modifiedMember);
+        member.changePassword(passwordEncoder.encode(password));
 
         return RsData.of("S-1", "비밀번호가 변경되었습니다.");
     }

--- a/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
@@ -287,12 +287,13 @@ public class MemberService {
     }
 
     @Transactional
-    public RsData modifyPassword(Member actor, String password, String oldPassword) {
-        if (!passwordEncoder.matches(oldPassword, actor.getPassword())) {
+    public RsData modifyPassword(Member member, String password, String oldPassword) {
+        if (!passwordEncoder.matches(oldPassword, member.getPassword())) {
             return RsData.of("F-1", "기존 비밀번호가 일치하지 않습니다.");
         }
 
-        actor.setPassword(passwordEncoder.encode(password));
+        Member modifiedMember = member.toBuilder().password(password).build();
+        memberRepository.save(modifiedMember);
 
         return RsData.of("S-1", "비밀번호가 변경되었습니다.");
     }

--- a/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
@@ -95,15 +95,18 @@ public class MemberService {
                 .profileImage(url)
                 .build();
 
-        emailVerificationService.send(member)
-                .addCallback(
-                        sendRsData -> {
-                            // 성공시 처리
-                        },
-                        error -> log.error(error.getMessage())
-                );
+        Member saveMember = memberRepository.save(member);
 
-        return RsData.of("S-1", "회원가입이 완료되었습니다.", memberRepository.save(member));
+        emailVerificationService.send(saveMember, email)
+                .thenAccept(sendRsData -> {
+                    // 성공시 처리
+                })
+                .exceptionally(error -> {
+                    log.error(error.getMessage());
+                    return null; // 에러 처리
+                });
+
+        return RsData.of("S-1", "회원가입이 완료되었습니다.", saveMember);
     }
     public String fileUpLoad(MultipartFile multipartFile, String username){
         return amazonService.uploadImage(multipartFile, S3FolderName.USER, username);

--- a/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/example/MnM/boundedContext/member/service/MemberService.java
@@ -10,6 +10,7 @@ import com.example.MnM.boundedContext.member.entity.Member;
 import com.example.MnM.boundedContext.member.repository.MemberRepository;
 import com.example.MnM.boundedContext.recommend.service.MbtiService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -29,6 +30,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional
 public class MemberService {
     private final MemberRepository memberRepository;
@@ -92,6 +94,14 @@ public class MemberService {
                 .createDate(LocalDateTime.now())
                 .profileImage(url)
                 .build();
+
+        emailVerificationService.send(member)
+                .addCallback(
+                        sendRsData -> {
+                            // 성공시 처리
+                        },
+                        error -> log.error(error.getMessage())
+                );
 
         return RsData.of("S-1", "회원가입이 완료되었습니다.", memberRepository.save(member));
     }
@@ -214,7 +224,8 @@ public class MemberService {
         }
 
         Member member = memberRepository.findById(id).get();
-        member.setEmailVerified(true);
+
+        member.setMemberEmailVerified(true);
 
         return RsData.of("S-1", "이메일인증이 완료되었습니다.");
     }

--- a/src/main/java/com/example/MnM/standard/util/Ut.java
+++ b/src/main/java/com/example/MnM/standard/util/Ut.java
@@ -71,5 +71,19 @@ public class Ut {
         }
     }
 
+    public static String getTempPassword(int length) {
+        int index = 0;
+        char[] charArr = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
+
+        StringBuffer sb = new StringBuffer();
+
+        for (int i = 0; i < length; i++) {
+            index = (int) (charArr.length * Math.random());
+            sb.append(charArr[index]);
+        }
+
+        return sb.toString();
+    }
+
 
 }

--- a/src/main/resources/application-secret.default
+++ b/src/main/resources/application-secret.default
@@ -24,6 +24,8 @@ spring:
           naver:
             client-id:
             client-secret:
+  mail:
+    password:
 secret:
   google:
     place:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,17 @@ spring:
     multipart:
       max-file-size: 5MB
       max-request-size: 5MB
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: nagt1997@gmail.com
+    password: NEED_TO_EMPTY
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
 decorator:
   datasource:
@@ -68,7 +79,10 @@ decorator:
 custom:
   site:
     baseUrl: http://localhost:8080
+    baseUrlWithPort: http://localhost:8080
+
   cookie:
     tokenValiditySeconds: '#{60 * 60 * 24 * 3}'
     key: "12345678"
+  siteName: "MnM"
 

--- a/src/main/resources/static/common/common.js
+++ b/src/main/resources/static/common/common.js
@@ -31,7 +31,7 @@ function parseMsg(msg) {
 function toastNotice(msg) {
     const [pureMsg, needToShow] = parseMsg(msg);
 
-    if (needToShow) {
+        if (needToShow) {
         toastr["success"](pureMsg, "알림");
     }
 }

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -36,11 +36,11 @@
 <!-- 테일윈드 불러오기 -->
 <script src="https://cdn.tailwindcss.com"></script>
 
-<div class="min-h-screen flex flex-col pb-10">
-  <header layout:fragment="header"></header>
 
-  <main layout:fragment="main"></main>
-</div>
+<header layout:fragment="header"></header>
+
+<main layout:fragment="main"></main>
+
 
 <script th:inline="javascript">
   if (params.msg) {

--- a/src/main/resources/templates/common/layout.html
+++ b/src/main/resources/templates/common/layout.html
@@ -1,4 +1,4 @@
-<html data-theme="light">
+<html data-theme="light" xmlns:layout="">
 
 <head>
   <meta charset="UTF-8">

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -32,11 +32,40 @@
 <!-- 데이지 UI 불러오기 -->
 <link href="https://cdn.jsdelivr.net/npm/daisyui@2.51.5/dist/full.css" rel="stylesheet" type="text/css"/>
 
-<nav th:replace="header/header::header"></nav>
 
-<th:block layout:fragment="content"></th:block>
+<div class="min-h-screen flex flex-col pb-10">
+  <nav th:replace="header/header::header"></nav>
 
+  <th:block layout:fragment="content"></th:block>
+</div>
 
+<script th:inline="javascript">
+  if (params.msg) {
+    toastNotice(params.msg[0]);
+  }
+
+  if (params.errorMsg) {
+    toastWarning(params.errorMsg[0]);
+  }
+
+  // history.back 에 의해서 돌아온 경우에 실행됨
+  // 평소에도 실행됨
+  $(window).bind("pageshow", function (event) {
+    const localStorageKeyAboutHistoryBackErrorMsg = "historyBackErrorMsg___" + location.href;
+
+    if (localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg)) {
+      toastWarning(localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg));
+      localStorage.removeItem(localStorageKeyAboutHistoryBackErrorMsg);
+    } else {
+      const localStorageKeyAboutHistoryBackErrorMsg = "historyBackErrorMsg___null";
+
+      if (localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg)) {
+        toastWarning(localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg));
+        localStorage.removeItem(localStorageKeyAboutHistoryBackErrorMsg);
+      }
+    }
+  });
+</script>
 
 </body>
 </html>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -33,11 +33,11 @@
 <link href="https://cdn.jsdelivr.net/npm/daisyui@2.51.5/dist/full.css" rel="stylesheet" type="text/css"/>
 
 
-<div class="min-h-screen flex flex-col pb-10">
-  <nav th:replace="header/header::header"></nav>
 
-  <th:block layout:fragment="content"></th:block>
-</div>
+<nav th:replace="header/header::header"></nav>
+
+<th:block layout:fragment="content"></th:block>
+
 
 <script th:inline="javascript">
   if (params.msg) {

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -22,7 +22,10 @@
   <script src="/common/common.js"></script>
   <!-- 공통 CSS 불러오기 -->
   <link rel="stylesheet" href="/common/common.css">
-
+  <script>
+    // 타임리프 문법(파라미터, ? 뒤에 입력된 매개변수들)
+    const params = JSON.parse('[( ${@rq.paramsJsonStr} )]');
+  </script>
 
 
 </head>

--- a/src/main/resources/templates/member/emailVerification.html
+++ b/src/main/resources/templates/member/emailVerification.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout.html}">
+<head>
+    <meta charset="UTF-8"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <title>이메일 인증</title>
+</head>
+<body layout:fragment="content" class="flex-col flex items-center justify-center">
+<main>
+    <section class="section section-login flex-grow flex flex-col items-center justify-center">
+        <div class="max-w-md w-full px-2 pt-4">
+            <h1 class="font-bold text-lg">
+                <i class="fa-solid fa-envelope-circle-check"></i>
+
+                이메일 인증
+            </h1>
+            <script>
+                let MemberEmailVerification__submitDone = false;
+
+                function MemberEmailVerification__submit(form) {
+                    if (MemberFindUsername__submitDone) {
+                        return;
+                    }
+
+                    form.email.value = form.email.value.trim();
+
+                    if (form.email.value.length === 0) {
+                        alert("이메일을 입력해주세요.");
+                        form.email.focus();
+
+                        return;
+                    }
+
+                    form.submit();
+                    MemberEmailVerification__submitDone = true;
+                }
+            </script>
+
+
+            <form th:action method="POST" class="flex flex-col gap-3"
+                  onsubmit="MemberEmailVerification__submit(this); return false;">
+
+                <div class="form-control">
+                    <label class="label">
+                        <span class="label-text">이메일</span>
+                    </label>
+                    <input autofocus type="email" name="email" placeholder="이메일" class="input input-bordered"
+                           maxlength="50">
+                </div>
+
+                <div class="grid grid-cols-2 mt-2 gap-2">
+                    <input class="btn btn-secondary" type="submit" value="인증 메일 보내기">
+                </div>
+            </form>
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/member/findPassword.html
+++ b/src/main/resources/templates/member/findPassword.html
@@ -65,9 +65,7 @@
                     <input type="email" name="email" placeholder="이메일" class="input input-bordered"
                            maxlength="50">
                 </div>
-            </form>
 
-            <div class="flex flex-col gap-3">
                 <div class="grid grid-cols-2 mt-2 gap-2">
                     <a href="/member/findUsername" class="btn btn-secondary btn-outline">아이디 찾기</a>
                     <input class="btn btn-primary" type="submit" value="비밀번호 찾기">
@@ -77,7 +75,7 @@
                     <a href="/member/login" class="btn btn-link">로그인</a>
                     <a href="/member/join" class="btn btn-link">회원가입</a>
                 </div>
-            </div>
+            </form>
         </div>
     </section>
 </main>

--- a/src/main/resources/templates/member/findPassword.html
+++ b/src/main/resources/templates/member/findPassword.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{usr/layout/layout.html}">
+<head>
+    <meta charset="UTF-8"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <title>비밀번호 찾기</title>
+</head>
+<body>
+<main layout:fragment="content" class="flex-col flex items-center justify-center">
+
+    <section class="section section-login flex-grow flex flex-col items-center justify-center">
+        <div class="max-w-md w-full px-2 pt-4">
+            <h1 class="font-bold text-lg">
+                <i class="fa-solid fa-unlock"></i>
+                비밀번호 찾기
+            </h1>
+
+            <script>
+                let MemberFindPassword__submitDone = false;
+
+                function MemberFindPassword__submit(form) {
+                    if (MemberFindPassword__submitDone) {
+                        return;
+                    }
+
+                    form.username.value = form.username.value.trim();
+
+                    if (form.username.value.length === 0) {
+                        alert("아이디를 입력해주세요.");
+                        form.username.focus();
+
+                        return;
+                    }
+
+                    form.email.value = form.email.value.trim();
+
+                    if (form.email.value.length === 0) {
+                        alert("이메일을 입력해주세요.");
+                        form.email.focus();
+
+                        return;
+                    }
+
+                    form.submit();
+                    MemberFindPassword__submitDone = true;
+                }
+            </script>
+
+
+            <form th:action method="POST" class="flex flex-col gap-3"
+                  onsubmit="MemberFindPassword__submit(this); return false;">
+                <div class="form-control">
+                    <label class="label">
+                        <span class="label-text">아이디</span>
+                    </label>
+                    <input autofocus type="text" name="userId" placeholder="아이디" class="input input-bordered"
+                           maxlength="50">
+                </div>
+
+                <div class="form-control">
+                    <label class="label">
+                        <span class="label-text">이메일</span>
+                    </label>
+                    <input type="email" name="email" placeholder="이메일" class="input input-bordered"
+                           maxlength="50">
+                </div>
+
+                <div class="grid grid-cols-2 mt-2 gap-2">
+                    <a href="/member/findUserId" class="btn btn-secondary btn-outline">아이디 찾기</a>
+                    <input class="btn btn-primary" type="submit" value="비밀번호 찾기">
+                </div>
+
+                <div class="flex justify-center">
+                    <a href="/member/login" class="btn btn-link">로그인</a>
+                    <a href="/member/join" class="btn btn-link">회원가입</a>
+                </div>
+            </form>
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/member/findUsername.html
+++ b/src/main/resources/templates/member/findUsername.html
@@ -46,9 +46,7 @@
                     </label>
                     <input autofocus type="email" name="email" placeholder="이메일" class="input input-bordered" maxlength="50">
                 </div>
-            </form>
 
-            <div class="flex flex-col gap-3">
                 <div class="grid grid-cols-2 mt-2 gap-2">
                     <a href="/member/findPassword" class="btn btn-secondary btn-outline">비밀번호 찾기</a>
                     <input class="btn btn-primary" type="submit" value="아이디찾기">
@@ -58,7 +56,7 @@
                     <a href="/member/login" class="btn btn-link">로그인</a>
                     <a href="/member/join" class="btn btn-link">회원가입</a>
                 </div>
-            </div>
+            </form>
         </div>
     </section>
 </main>

--- a/src/main/resources/templates/member/findUsername.html
+++ b/src/main/resources/templates/member/findUsername.html
@@ -4,73 +4,54 @@
 <head>
     <meta charset="UTF-8"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-    <title>비밀번호 찾기</title>
+    <title>아이디 찾기</title>
 </head>
 <body>
 <main layout:fragment="content" class="flex-col flex items-center justify-center">
-
     <section class="section section-login flex-grow flex flex-col items-center justify-center">
         <div class="max-w-md w-full px-2 pt-4">
             <h1 class="font-bold text-lg">
-                <i class="fa-solid fa-unlock"></i>
-                비밀번호 찾기
+                <i class="fa-solid fa-fingerprint"></i>
+
+                아이디 찾기
             </h1>
 
             <script>
-                let MemberFindPassword__submitDone = false;
+                let MemberFindUsername__submitDone = false;
 
-                function MemberFindPassword__submit(form) {
-                    if (MemberFindPassword__submitDone) {
-                        return;
-                    }
-
-                    form.username.value = form.username.value.trim();
-
-                    if (form.username.value.length === 0) {
-                        alert("아이디를 입력해주세요.");
-                        form.username.focus();
-
+                function MemberFindUsername__submit(form) {
+                    if (MemberFindUsername__submitDone) {
                         return;
                     }
 
                     form.email.value = form.email.value.trim();
 
                     if (form.email.value.length === 0) {
-                        alert("이메일을 입력해주세요.");
+                        alert("아이디를 입력해주세요.");
                         form.email.focus();
 
                         return;
                     }
 
                     form.submit();
-                    MemberFindPassword__submitDone = true;
+                    MemberFindUsername__submitDone = true;
                 }
             </script>
 
 
-            <form th:action method="POST" class="flex flex-col gap-3"
-                  onsubmit="MemberFindPassword__submit(this); return false;">
-                <div class="form-control">
-                    <label class="label">
-                        <span class="label-text">아이디</span>
-                    </label>
-                    <input autofocus type="text" name="username" placeholder="아이디" class="input input-bordered"
-                           maxlength="50">
-                </div>
-
+            <form th:action method="POST" class="flex flex-col gap-3" onsubmit="MemberFindUsername__submit(this); return false;">
                 <div class="form-control">
                     <label class="label">
                         <span class="label-text">이메일</span>
                     </label>
-                    <input type="email" name="email" placeholder="이메일" class="input input-bordered"
-                           maxlength="50">
+                    <input autofocus type="email" name="email" placeholder="이메일" class="input input-bordered" maxlength="50">
                 </div>
             </form>
 
             <div class="flex flex-col gap-3">
                 <div class="grid grid-cols-2 mt-2 gap-2">
-                    <a href="/member/findUsername" class="btn btn-secondary btn-outline">아이디 찾기</a>
-                    <input class="btn btn-primary" type="submit" value="비밀번호 찾기">
+                    <a href="/member/findPassword" class="btn btn-secondary btn-outline">비밀번호 찾기</a>
+                    <input class="btn btn-primary" type="submit" value="아이디찾기">
                 </div>
 
                 <div class="flex justify-center">

--- a/src/main/resources/templates/member/join.html
+++ b/src/main/resources/templates/member/join.html
@@ -33,26 +33,26 @@
     <script>
         function MemberDto__submit(form) {
 
-            form.username.value = form.username.value.trim();
+            form.name.value = form.name.value.trim();
 
-            if (form.username.value.length === 0) {
+            if (form.name.value.length === 0) {
                 alert('이름을 입력해주세요.');
-                form.username.focus();
+                form.name.focus();
                 console.log()
                 return;
             }
 
-            form.userId.value = form.userId.value.trim();
+            form.username.value = form.username.value.trim();
 
-            if (form.userId.value.length === 0) {
+            if (form.username.value.length === 0) {
                 alert('아이디를 입력해주세요.');
-                form.userId.focus();
+                form.username.focus();
                 return;
             }
 
-            if (form.userId.value.length < 4) {
+            if (form.username.value.length < 4) {
                 alert('아이디를 4자 이상 입력해주세요.');
-                form.userId.focus();
+                form.username.focus();
                 return;
             }
 
@@ -169,8 +169,10 @@
         <div class="input-form-backgroud row">
             <div class="input-form col-md-12 mx-auto">
                 <h4 class="mb-3">회원가입</h4>
+
                 <form th:action="@{/member/join}" method="POST" class="flex flex-col justify-center" enctype="multipart/form-data"
                       onsubmit="MemberDto__submit(this); return false;">
+
                     <div class="row">
                         <div class="col-md-6 mb-3">
                             <label for="name">이름</label>
@@ -307,7 +309,9 @@
                     </div>
                     <div class="mb-4"></div>
                     <button class="btn btn-secondary btn-lg btn-block" type="submit">가입하기</button>
+
                 </form>
+
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/member/join.html
+++ b/src/main/resources/templates/member/join.html
@@ -202,7 +202,7 @@
                     <div class="mb-3">
                         <label for="email">이메일</label>
                         <input type="email" class="input input-bordered input-secondary w-full max-w-xl" id="email"
-                               placeholder="you@example.com" required>
+                               placeholder="you@example.com">
 
 
                     </div>

--- a/src/main/resources/templates/member/join.html
+++ b/src/main/resources/templates/member/join.html
@@ -36,7 +36,7 @@
             form.name.value = form.name.value.trim();
 
             if (form.name.value.length === 0) {
-                alert('이름을 입력해주세요.');
+                toastWarning('이름을 입력해주세요.');
                 form.name.focus();
                 console.log()
                 return;
@@ -45,13 +45,13 @@
             form.username.value = form.username.value.trim();
 
             if (form.username.value.length === 0) {
-                alert('아이디를 입력해주세요.');
+                toastWarning('아이디를 입력해주세요.');
                 form.username.focus();
                 return;
             }
 
             if (form.username.value.length < 4) {
-                alert('아이디를 4자 이상 입력해주세요.');
+                toastWarning('아이디를 4자 이상 입력해주세요.');
                 form.username.focus();
                 return;
             }
@@ -59,19 +59,19 @@
             form.password.value = form.password.value.trim();
 
             if (form.password.value.length === 0) {
-                alert('비밀번호를 입력해주세요.');
+                toastWarning('비밀번호를 입력해주세요.');
                 form.password.focus();
                 return;
             }
 
             if (form.password.value.length < 4) {
-                alert('비밀번호를 4자 이상 입력해주세요.');
+                toastWarning('비밀번호를 4자 이상 입력해주세요.');
                 form.password.focus();
                 return;
             }
 
             if (form.password_check.value !== form.password.value) {
-                alert('비밀번호를 확인해주세요.');
+                toastWarning('비밀번호를 확인해주세요.');
                 form.password_check.value = '';
                 form.password_check.focus();
                 return;
@@ -80,7 +80,7 @@
             form.nickname.value = form.nickname.value.trim();
 
             if (form.nickname.value.length === 0) {
-                alert('닉네임을 입력해주세요.');
+                toastWarning('닉네임을 입력해주세요.');
                 form.nickname.focus();
                 return;
             }
@@ -88,11 +88,11 @@
             form.email.value = form.email.value.trim();
 
             if (form.email.value.length === 0) {
-                alert('이메일을 입력해주세요.');
+                toastWarning('이메일을 입력해주세요.');
                 form.email.focus();
                 return;
             } else if (!validateEmail(form.email.value)) {
-                alert('올바른 형식의 이메일 주소를 입력해주세요.');
+                toastWarning('올바른 형식의 이메일 주소를 입력해주세요.');
                 form.email.focus();
                 return;
             }
@@ -100,32 +100,32 @@
             form.age.value = form.age.value.trim();
 
             if (form.age.value.length === 0) {
-                alert('나이를 입력해주세요.');
+                toastWarning('나이를 입력해주세요.');
                 form.age.focus();
                 return;
             }
 
             form.height.value = form.height.value.trim();
             if (form.height.value.length === 0) {
-                alert('키를 입력해주세요.');
+                toastWarning('키를 입력해주세요.');
                 form.height.focus();
                 return;
             }
 
             if (form.gender.value === '') {
-                alert('성별을 선택해주세요.');
+                toastWarning('성별을 선택해주세요.');
                 form.gender.focus();
                 return;
             }
 
             if (form.locate.value === '') {
-                alert('사는 지역을 선택해주세요.');
+                toastWarning('사는 지역을 선택해주세요.');
                 form.locate.focus();
                 return;
             }
 
             if (form.mbti.value === '') {
-                alert('mbti를 선택해주세요.');
+                toastWarning('mbti를 선택해주세요.');
                 form.mbti.focus();
                 return;
             }
@@ -133,7 +133,7 @@
             form.hobby.value = form.hobby.value.trim();
 
             if (form.hobby.value.length === 0) {
-                alert('취미를 입력해주세요.');
+                toastWarning('취미를 입력해주세요.');
                 form.hobby.focus();
                 return;
             }
@@ -141,14 +141,14 @@
             form.introduce.value = form.introduce.value.trim();
 
             if (form.introduce.value.length === 0) {
-                alert('취미를 입력해주세요.');
+                toastWarning('취미를 입력해주세요.');
                 form.introduce.focus();
                 return;
             }
 
 
             if (!form.personalInfoAgreement.checked) {
-                alert('개인정보 수집 및 활용 약관에 동의해주세요.')
+                toastWarning('개인정보 수집 및 활용 약관에 동의해주세요.')
                 form.personalInfoAgreement.focus();
                 return;
             }
@@ -202,13 +202,13 @@
                     <div class="mb-3">
                         <label for="email">이메일</label>
                         <input type="email" class="input input-bordered input-secondary w-full max-w-xl" id="email"
-                               placeholder="you@example.com">
+                               placeholder="you@example.com" name = "email">
 
 
                     </div>
                     <div class="mb-3">
                         <label for="nickname">닉네임</label>
-                        <input type="text" class="input input-bordered input-secondary w-full max-w-xl" id="nickname">
+                        <input type="text" class="input input-bordered input-secondary w-full max-w-xl" id="nickname" name = "nickname">
                     </div>
 
                     <div class="mb-3">

--- a/src/main/resources/templates/member/login.html
+++ b/src/main/resources/templates/member/login.html
@@ -28,14 +28,15 @@
     function LoginForm__submit(form) {
         form.username.value = form.username.value.trim();
 
+
         if (form.username.value.length === 0) {
-            alert('아이디를 입력해주세요.');
+            toastWarning('아이디를 입력해주세요');
             form.username.focus();
             return;
         }
 
         if (form.username.value.length < 4) {
-            alert('아이디를 4자 이상 입력해주세요.');
+            toastWarning('아이디를 4자 이상 입력해주세요.');
             form.username.focus();
             return;
         }
@@ -44,18 +45,19 @@
 
         if (form.password.value.length === 0) {
             form.password.focus();
-            alert('비밀번호를 입력해주세요.');
+            toastWarning('비밀번호를 입력해주세요.');
             return;
         }
 
         if (form.password.value.length < 4) {
-            alert('비밀번호를 4자 이상 입력해주세요.');
+            toastWarning('비밀번호를 4자 이상 입력해주세요.');
             form.password.focus();
             return;
         }
 
         form.submit(); // 폼 발송
     }
+
 </script>
 <main>
     <div class="container">
@@ -101,10 +103,12 @@
                             </div>
 
                             <!-- Forgot password link -->
-                            <a
-                                    href="#!"
-                                    class="ml-80 text-primary"
-                            >비밀번호 찾기</a>
+
+                            <div class = "content-end">
+                                <a href="/member/findUsername" class="ml-80 text-primary">아이디</a>
+                                <a class="ml-80 text-primary"> / </a>
+                                <a href="/member/findPassword" class="ml-80 text-primary">비밀번호 찾기</a>
+                            </div>
                         </div>
 
                         <!-- Submit button -->

--- a/src/main/resources/templates/member/me.html
+++ b/src/main/resources/templates/member/me.html
@@ -13,11 +13,13 @@
       confirm('회원을 탈퇴 하시겠습니까?');
     }
   </script>
-
-  <div class="avatar">
-    <div class="w-52 rounded flex items-center justify-center">
-      <img th:src="${member.getProfileImage()}"/>
+  <div class = "flex items-center justify-center">
+    <div class="avatar">
+      <div class="w-52 rounded flex items-center justify-center">
+        <img th:src="${member.getProfileImage()}"/>
+      </div>
     </div>
+    <a href="/member/editProfile" class="btn btn-secondary flex justify-end gap-1"> 프로필 수정 </a>
   </div>
 
   <table class="table" style="width: 500px">
@@ -36,6 +38,12 @@
     <tr>
       <th>이메일</th>
       <td th:text="${member.getEmail()}" colspan="2"></td>
+    </tr>
+    <tr>
+      <th>이메일 인증 여부</th>
+      <td th:if="${member.emailVerified} == true" colspan="2">인증완료</td>
+      <td th:unless="${member.emailVerified}" colspan="2"><a href="/member/emailVerification" class="btn btn-secondary">이메일
+        인증하러 가기</a></td>
     </tr>
     <tr>
       <th>가입일</th>
@@ -68,7 +76,6 @@
 
   </table>
   <div class="flex justify-end gap-1">
-    <a href="/member/editProfile" class="btn btn-secondary"> 프로필 수정 </a>
     <a href="/member/editMyPage" class="btn btn-secondary"> 회원 수정 </a>
     <a href="/member/delete" class="btn btn-secondary" onclick="deleteUser()"> 회원 탈퇴 </a>
   </div>

--- a/src/main/resources/templates/member/me.html
+++ b/src/main/resources/templates/member/me.html
@@ -7,7 +7,7 @@
   <title>myPage</title>
 </head>
 <body layout:fragment="content" class="flex-col flex items-center justify-center">
-<main class="pt-2">
+<main class="pt-2 ">
   <script>
     function deleteUser() {
       confirm('회원을 탈퇴 하시겠습니까?');
@@ -22,7 +22,7 @@
     <a href="/member/editProfile" class="btn btn-secondary flex justify-end gap-1"> 프로필 수정 </a>
   </div>
 
-  <table class="table" style="width: 500px">
+  <table class="table items-center justify-center" style="width: 500px">
     <tr>
       <th>이름</th>
       <td th:text="${member.getName()}" colspan="2"></td>

--- a/src/main/resources/templates/member/me.html
+++ b/src/main/resources/templates/member/me.html
@@ -76,6 +76,7 @@
 
   </table>
   <div class="flex justify-end gap-1">
+    <a href="/member/modifyPassword" class="btn btn-secondary">비밀번호 변경하기</a>
     <a href="/member/editMyPage" class="btn btn-secondary"> 회원 수정 </a>
     <a href="/member/delete" class="btn btn-secondary" onclick="deleteUser()"> 회원 탈퇴 </a>
   </div>

--- a/src/main/resources/templates/member/modifyPassword.html
+++ b/src/main/resources/templates/member/modifyPassword.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout.html}">
+<head>
+    <meta charset="UTF-8"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <title>비밀번호 변경</title>
+</head>
+<body layout:fragment="content" class="flex-col flex items-center justify-center">
+<script th:inline="javascript">
+    const message = /*[[ ${message} ]]*/ null;
+    if (message) {
+        alert(message);
+    }
+</script>
+<section class="section section-login flex-grow flex flex-col items-center justify-center">
+
+    <div class="max-w-md w-full px-2 pt-4">
+        <h1 class="font-bold text-lg">
+            <i class="fa-solid fa-lock"></i>
+
+            비밀번호 변경
+        </h1>
+
+        <script>
+            let MemberModifyPassword__submitDone = false;
+
+            function MemberModifyPassword__submit(form) {
+                if (MemberModifyPassword__submitDone) {
+                    return;
+                }
+
+                form.oldPassword.value = form.oldPassword.value.trim();
+
+                if (form.oldPassword.value.length === 0) {
+                    warningModal("기존 패스워드를 입력해주세요.");
+                    form.oldPassword.focus();
+
+                    return;
+                }
+
+                form.password.value = form.password.value.trim();
+
+                if (form.password.value.length === 0) {
+                    warningModal("비밀번호를 입력해주세요.");
+                    form.password.focus();
+
+                    return;
+                }
+
+                form.submit();
+                MemberModifyPassword__submitDone = true;
+            }
+        </script>
+
+
+        <form th:action method="POST" class="flex flex-col gap-3"
+              onsubmit="MemberModifyPassword__submit(this); return false;">
+            <div class="form-control">
+                <label class="label">
+                    <span class="label-text">기존 비밀번호</span>
+                </label>
+                <input type="password" name="oldPassword"
+                       placeholder="기존 비밀번호" class="input input-bordered" maxlength="50">
+            </div>
+
+            <div class="form-control">
+                <label class="label">
+                    <span class="label-text">비밀번호</span>
+                </label>
+                <input type="password" name="password"
+                       placeholder="비밀번호" class="input input-bordered" maxlength="50">
+            </div>
+
+            <input class="btn btn-primary" type="submit" value="비밀번호 변경">
+        </form>
+    </div>
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/member/modifyPassword.html
+++ b/src/main/resources/templates/member/modifyPassword.html
@@ -66,7 +66,7 @@
 
             <div class="form-control">
                 <label class="label">
-                    <span class="label-text">비밀번호</span>
+                    <span class="label-text">새 비밀번호</span>
                 </label>
                 <input type="password" name="password"
                        placeholder="비밀번호" class="input input-bordered" maxlength="50">


### PR DESCRIPTION
## PR 생성이유
---
이메일 인증, 아이디/ 비밀번호를 찾기, 비밀번호 변경 기능 추가

## 주요 변화사항
---
회원가입시 이메일 인증을 합니다
아이디/ 비밀번호를 찾을 수 있습니다. (일반 회원), 이메일 기
비밀번호 변경이 가능합니다.
toastr코드 추가했습니다. 아직 historyback만 가능

appConfig에 변수 추가
시큐리티 권한 추가
회원가입 admin단어 포함 불가, 영어와 숫자로만 생성가능
메일 확인 비동기 처리

임시 패스워드 발동 하드코딩 -> 추후 개선하겠습니다.
ut에 비밀번호 임의 생성 메소드 추가
mysql추가
메일 제껄로 발송됩니다.

template안에 common안에 lauout이라는 또라는 레이아웃이 있는것 같습니다 삭제 필요할 것 같습니다.

+++추가
코드 수정했습니다

## 이 부분을 중점으로 봐주세요
---
하드코딩해놓은 부분들이있습니다. 추후 개선하겠습니다.
코드의 중복, 보안, 정리가 필요한 부분들 외 모든 부분


Close #64 #68 #69 
